### PR TITLE
Link newly created missions to ownder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,6 +1934,12 @@
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -18364,6 +18370,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-promise-core": {
@@ -19179,6 +19192,11 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -20467,9 +20485,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -21274,6 +21292,13 @@
           "requires": {
             "ansi-colors": "^3.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         }
       }
@@ -21998,6 +22023,13 @@
           "requires": {
             "ansi-colors": "^3.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         },
         "ws": {
@@ -22059,6 +22091,13 @@
         "log-symbols": "^2.1.0",
         "loglevelnext": "^1.0.1",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "redux-firestore": "^0.13.0",
     "reselect": "^4.0.0",
     "source-map-loader": "^0.2.4",
-    "styled-components": "^5.0.1"
+    "styled-components": "^5.0.1",
+    "uuid": "^7.0.2"
   },
   "scripts": {
     "server": "node server.js",

--- a/src/app/model/User.js
+++ b/src/app/model/User.js
@@ -1,20 +1,40 @@
-import { createSelector } from "reselect";
-import { getFirebase } from "react-redux-firebase";
 import { get } from "lodash";
 
 class User {
-  assginedToMission(fs, missionId, assignedId) {
-    fs.update(
-      { collection: "missions", doc: missionId },
-      { status: "doing", assignedId: assignedId }
-    );
-    fs.collection("users")
-      .doc(assignedId)
-      .update({
-        assigned: fs.FieldValue.arrayUnion(missionId),
-      });
+  /**
+   * Assign the current user as a volunteer for the mission with the given missionId
+   * @param {object} fs
+   * @param {string} missionId
+   * @param {string} userId
+   * @param {string} status
+   */
+  assignAsVolunteer(fs, missionId, userId, status = "doing") {
+    this._assignUserToMission(fs, missionId, userId, "volunteerId", status);
   }
 
+  /**
+   * Assign the current user as an owner for the mission with the given missionId
+   * @param {object} fs
+   * @param {string} missionId
+   * @param {string} userId
+   */
+  assignAsOwner(fs, missionId, userId) {
+    this._assignUserToMission(fs, missionId, userId, "ownerId");
+  }
+
+  _assignUserToMission(fs, missionId, userId, assignmentType, status) {
+    const missionData = status
+      ? { status: status, [assignmentType]: userId }
+      : { [assignmentType]: userId };
+
+    fs.collection("missions").doc(missionId).update(missionData);
+
+    fs.collection("users")
+      .doc(userId)
+      .update({
+        assignedMissionIds: fs.FieldValue.arrayUnion(missionId),
+      });
+  }
   getAuth = (state) => get(state, "firebase.auth");
 }
 

--- a/src/app/model/User.js
+++ b/src/app/model/User.js
@@ -9,7 +9,15 @@ class User {
    * @param {string} status
    */
   assignAsVolunteer(fs, missionId, userId, status = "doing") {
-    this._assignUserToMission(fs, missionId, userId, "volunteerId", status);
+    //this._assignUserToMission(fs, missionId, userId, "volunteerId", status);
+
+    fs.collection("missions").doc(missionId).update({ volunteerId: userId, status: status });
+
+    fs.collection("users")
+      .doc(userId)
+      .update({
+        volunteeringMissionIds: fs.FieldValue.arrayUnion(missionId),
+      });
   }
 
   /**
@@ -18,23 +26,18 @@ class User {
    * @param {string} missionId
    * @param {string} userId
    */
-  assignAsOwner(fs, missionId, userId) {
-    this._assignUserToMission(fs, missionId, userId, "ownerId");
-  }
+  assignAsOwner(fs, missionId, userId, status = "todo") {
+    //this._assignUserToMission(fs, missionId, userId, "ownerId");
 
-  _assignUserToMission(fs, missionId, userId, assignmentType, status) {
-    const missionData = status
-      ? { status: status, [assignmentType]: userId }
-      : { [assignmentType]: userId };
-
-    fs.collection("missions").doc(missionId).update(missionData);
+    fs.collection("missions").doc(missionId).update({ ownerId: userId, status: status });
 
     fs.collection("users")
       .doc(userId)
       .update({
-        assignedMissionIds: fs.FieldValue.arrayUnion(missionId),
+        owningMissionIds: fs.FieldValue.arrayUnion(missionId),
       });
   }
+
   getAuth = (state) => get(state, "firebase.auth");
 }
 

--- a/src/app/page/Missions/Missions.jsx
+++ b/src/app/page/Missions/Missions.jsx
@@ -7,7 +7,6 @@ import { useHistory } from "react-router-dom";
 import { User } from "../../model";
 import { MissionCard } from "../../component";
 
-
 const MissionsPage = ({ firestore }) => {
   let history = useHistory();
   useFirestoreConnect([{ collection: "missions" }]);
@@ -20,8 +19,7 @@ const MissionsPage = ({ firestore }) => {
   }
 
   function volunteerForMission(missionId) {
-    User.assginedToMission(firestore, missionId, user.uid);
-
+    User.assignAsVolunteer(firestore, missionId, user.uid);
   }
 
   return (


### PR DESCRIPTION
When a logged user creates a new request/mission, we add them as owner to the mission document. We also add a mission entry in the user document to reflect how many and what missions they have created.

Notes:
- I had to use the uuid package to create mission uid. This means that we are not relying on Firebase to create a uid for mission any more. I had to do this because to save the mission Id on the user doc, I needed access to the mission Id, which, if we used Firebase's default uid, is hidden at that point.
- Refactor: I refactored some code on User model. We should check for regressions when a user clicks to volunteer for a mission.