### PR TITLE
Link Phone before volunteering. 

### DIFF
--- a/src/app/component/PhoneLoginForm/PhoneLoginForm.jsx
+++ b/src/app/component/PhoneLoginForm/PhoneLoginForm.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Grid, TextField, Button } from "@material-ui/core";
+export default function PhoneLoginForm(props) {
+  const { handlePhoneLogin, handlePhoneNumberChange } = props;
+  return (
+    <Grid container spacing={1} direction="column">
+      <Grid item>
+        <TextField
+          id="phone-number"
+          label="Phone Number"
+          type="text"
+          helperText="+1 777-777-7777 VerificationCode: 123456"
+          variant="outlined"
+          required
+          onChange={handlePhoneNumberChange}
+        />
+      </Grid>
+      <Grid item style={{ alignSelf: "center" }}>
+        <Button id="sms-sign-in" onClick={handlePhoneLogin} color="secondary" variant="contained">
+          Sign in with phone
+        </Button>
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/app/component/PhoneLoginForm/index.js
+++ b/src/app/component/PhoneLoginForm/index.js
@@ -1,0 +1,3 @@
+import PhoneLoginForm from "./PhoneLoginForm";
+
+export default PhoneLoginForm;

--- a/src/app/model/User.js
+++ b/src/app/model/User.js
@@ -39,6 +39,24 @@ class User {
       });
   }
 
+  linkPhoneAuthentication(firebase, phoneNumber, recaptchaVerfier, callback) {
+    return firebase
+      .auth()
+      .currentUser.linkWithPhoneNumber(phoneNumber, recaptchaVerfier)
+      .then(function (confirmationResult) {
+        var code = window.prompt("Provide your SMS code");
+        recaptchaVerfier.clear();
+        return confirmationResult.confirm(code).then(() => {
+          callback();
+        });
+      })
+      .catch((err) =>
+        alert(
+          "You already have an account associated with this phone number. Please sign in using that number."
+        )
+      );
+  }
+
   getAuth = (state) => get(state, "firebase.auth");
 }
 


### PR DESCRIPTION
feat: if someone who doesn't have a phone number wants to volunteer we force them to authenticate their number. The UX is as follows:

Sign In with Google/FB -> Try to Volunteer -> Cant because you do not have phone number -> Simple form to authenticate phone -> Happy Path: We link your phone auth and your non phone auth together. Sad Path: You already created an account with Phone number before, so we cannot link these two different accounts yet. We prompt you to sign in with that account.

