### PR TITLE
Loading Spinners

### DIFF
--- a/src/app/page/Missions/Missions.jsx
+++ b/src/app/page/Missions/Missions.jsx
@@ -3,7 +3,7 @@ import { useFirestore, firestoreConnect } from "react-redux-firebase";
 import { useSelector, connect } from "react-redux";
 import { withRouter, Link } from "react-router-dom";
 
-import { Typography, Button, Grid } from "@material-ui/core";
+import { CircularProgress, Typography, Button, Grid } from "@material-ui/core";
 import styled from "styled-components";
 
 import { Page, Card } from "../../layout";
@@ -40,41 +40,41 @@ const MissionsPage = ({ user, history, firebase, ...rest }) => {
     }
   }
 
-  if (!missions) {
-    return <div> isloading...</div>;
-  }
   return (
     <Page template="pink">
       <StyledHeader variant="h1"> Missions </StyledHeader>
+      {missions ? (
+        missions.map((mission) => (
+          <Card key={mission.id}>
+            <MissionCard mission={mission} key={`preview-${mission.id}`} />
 
-      {missions.map((mission) => (
-        <Card key={mission.id}>
-          <MissionCard mission={mission} key={`preview-${mission.id}`} />
-
-          <Grid container justify="center" alignItems="center">
-            <StyledButton
-              color="primary"
-              size="large"
-              variant="contained"
-              disableElevation
-              onClick={() => volunteerForMission(mission.id)}
-            >
-              Volunteer
-            </StyledButton>
-            <PlaceHolder />
-            <StyledButton
-              variant="outlined"
-              size="large"
-              color="secondary"
-              onClick={() => {
-                history.push(`/missions/${mission.id}`);
-              }}
-            >
-              Details
-            </StyledButton>
-          </Grid>
-        </Card>
-      ))}
+            <Grid container justify="center" alignItems="center">
+              <StyledButton
+                color="primary"
+                size="large"
+                variant="contained"
+                disableElevation
+                onClick={() => volunteerForMission(mission.id)}
+              >
+                Volunteer
+              </StyledButton>
+              <PlaceHolder />
+              <StyledButton
+                variant="outlined"
+                size="large"
+                color="secondary"
+                onClick={() => {
+                  history.push(`/missions/${mission.id}`);
+                }}
+              >
+                Details
+              </StyledButton>
+            </Grid>
+          </Card>
+        ))
+      ) : (
+        <CircularProgress />
+      )}
       <Popup
         title="Add a Phone Number"
         open={popupOpen}

--- a/src/app/page/MissionsCreated/Missions.jsx
+++ b/src/app/page/MissionsCreated/Missions.jsx
@@ -3,7 +3,7 @@ import { firestoreConnect } from "react-redux-firebase";
 import { useSelector, connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 
-import { Typography, Button, Grid } from "@material-ui/core";
+import { CircularProgress, Typography, Button, Grid } from "@material-ui/core";
 import styled from "styled-components";
 
 import { Page, Card } from "../../layout";
@@ -25,24 +25,28 @@ const MissionsPage = ({ auth, history, firebase, ...rest }) => {
     <Page template="pink">
       <StyledHeader variant="h1"> My Requests</StyledHeader>
 
-      {missions?.map((mission) => (
-        <Card key={mission.id}>
-          <MissionCard mission={mission} key={`preview-${mission.id}`} />
+      {missions ? (
+        missions.map((mission) => (
+          <Card key={mission.id}>
+            <MissionCard mission={mission} key={`preview-${mission.id}`} />
 
-          <Grid container justify="center" alignItems="center">
-            <StyledButton
-              variant="outlined"
-              size="large"
-              color="secondary"
-              onClick={() => {
-                history.push(`/missions/${mission.id}`);
-              }}
-            >
-              Details
-            </StyledButton>
-          </Grid>
-        </Card>
-      ))}
+            <Grid container justify="center" alignItems="center">
+              <StyledButton
+                variant="outlined"
+                size="large"
+                color="secondary"
+                onClick={() => {
+                  history.push(`/missions/${mission.id}`);
+                }}
+              >
+                Details
+              </StyledButton>
+            </Grid>
+          </Card>
+        ))
+      ) : (
+        <CircularProgress />
+      )}
     </Page>
   );
 };

--- a/src/app/page/MissionsVolunteered/Missions.jsx
+++ b/src/app/page/MissionsVolunteered/Missions.jsx
@@ -3,7 +3,7 @@ import { useFirestore, firestoreConnect } from "react-redux-firebase";
 import { useSelector, connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 
-import { Typography, Button, Grid } from "@material-ui/core";
+import { CircularProgress, Typography, Button, Grid } from "@material-ui/core";
 import styled from "styled-components";
 
 import { Page, Card } from "../../layout";
@@ -31,41 +31,42 @@ const MissionsPage = ({ auth, history, firebase, ...rest }) => {
     User.assignAsVolunteer(firestore, missionId, auth.uid);
   }
 
-  if (!missions) {
-    return <div> isloading...</div>;
-  }
   return (
     <Page template="pink">
       <StyledHeader variant="h1"> Missions </StyledHeader>
 
-      {missions.map((mission) => (
-        <Card key={mission.id}>
-          <MissionCard mission={mission} key={`preview-${mission.id}`} />
+      {missions ? (
+        missions.map((mission) => (
+          <Card key={mission.id}>
+            <MissionCard mission={mission} key={`preview-${mission.id}`} />
 
-          <Grid container justify="center" alignItems="center">
-            <StyledButton
-              color="primary"
-              size="large"
-              variant="contained"
-              disableElevation
-              onClick={() => volunteerForMission(mission.id)}
-            >
-              Volunteer
-            </StyledButton>
-            <PlaceHolder />
-            <StyledButton
-              variant="outlined"
-              size="large"
-              color="secondary"
-              onClick={() => {
-                history.push(`/missions/${mission.id}`);
-              }}
-            >
-              Details
-            </StyledButton>
-          </Grid>
-        </Card>
-      ))}
+            <Grid container justify="center" alignItems="center">
+              <StyledButton
+                color="primary"
+                size="large"
+                variant="contained"
+                disableElevation
+                onClick={() => volunteerForMission(mission.id)}
+              >
+                Volunteer
+              </StyledButton>
+              <PlaceHolder />
+              <StyledButton
+                variant="outlined"
+                size="large"
+                color="secondary"
+                onClick={() => {
+                  history.push(`/missions/${mission.id}`);
+                }}
+              >
+                Details
+              </StyledButton>
+            </Grid>
+          </Card>
+        ))
+      ) : (
+        <CircularProgress />
+      )}
     </Page>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -20,3 +20,7 @@ p {
 .MuiButton-root {
   text-transform: capitalize !important;
 }
+
+.MuiCircularProgress-root {
+  margin: auto;
+}


### PR DESCRIPTION
Add loading spinners to Missions pages at the list level so the page header is still visible. Added in a style injection for MUI circular progress component at the app level to center circular progress components. Please let me know if you have any questions. #121