### PR TITLE
Removes requester information from mission details

### DIFF
--- a/src/app/component/MissionCard.jsx
+++ b/src/app/component/MissionCard.jsx
@@ -2,22 +2,9 @@ import React from "react";
 import { Typography, Grid } from "@material-ui/core";
 import LocationOnIcon from "@material-ui/icons/LocationOn";
 
+import { missionStatusLabel } from '../../constants';
+
 const MissionCard = ({ mission }) => {
-  let status = "";
-  switch (mission.status) {
-    case "todo":
-      status = "need volunteers";
-      break;
-    case "doing":
-      status = "in progress";
-      break;
-    case "done":
-      status = "done";
-      break;
-    case "finished":
-    default:
-      status = "finished";
-  }
   return (
     <Grid container spacing={1}>
       <Grid container item>
@@ -30,7 +17,7 @@ const MissionCard = ({ mission }) => {
         <Typography variant="body2">123 Example St., San Francisco, 92501</Typography>
       </Grid>
       <Grid container item>
-        <Typography variant="h4">status: {status}</Typography>
+        <Typography variant="h4">status: {missionStatusLabel[mission.status]}</Typography>
       </Grid>
     </Grid>
   );

--- a/src/app/page/MissionDetails/MissionDetailsContainer.jsx
+++ b/src/app/page/MissionDetails/MissionDetailsContainer.jsx
@@ -44,11 +44,6 @@ const MissionDetailsPage = ({ firestore, auth, mission, history }) => {
     }
   }
 
-  let requester = {
-    name: "Audrey",
-    address: "123 Example st, San Fransisco, 92501",
-  };
-
   // functionality for the map look up
   const [cords, setCords] = useState();
 
@@ -65,7 +60,6 @@ const MissionDetailsPage = ({ firestore, auth, mission, history }) => {
     <Page key="mission-detail" isLoaded={isLoaded(mission)} isEmpty={isEmpty(mission)}>
       <MissionDetailsView
         mission={mission}
-        requester={requester}
         volunteerForMission={volunteerForMission}
         userUnverifiedPopupOpen={userUnverifiedPopupOpen}
         setUserUnverifiedPopupOpen={setUserUnverifiedPopupOpen}

--- a/src/app/page/MissionDetails/MissionDetailsView.jsx
+++ b/src/app/page/MissionDetails/MissionDetailsView.jsx
@@ -4,13 +4,12 @@ import { Button } from "../../component";
 import { Typography, Grid, Box } from "@material-ui/core";
 import { Card } from "../../layout";
 
-import profileImg from "../../../img/fb-profile.jpg";
-import { ReactComponent as MapMarkerImg } from "../../../img/map-marker-alt.svg";
 // Created based on the schema in firebase
 import styled from "styled-components";
 
 import MapView from "../../component/MapView";
 import UserPhoneUnverifiedPopup from "../../component/UserPhoneUnverifiedPopup";
+import { missionStatusLabel } from '../../../constants';
 
 export const StyledHr = styled.hr`
   border: 1px dashed #de3254;

--- a/src/app/page/MissionDetails/MissionDetailsView.jsx
+++ b/src/app/page/MissionDetails/MissionDetailsView.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { Button } from "../../component";
-import { Typography, Avatar, Grid, Box } from "@material-ui/core";
+import { Typography, Grid, Box } from "@material-ui/core";
 import { Card } from "../../layout";
 
 import profileImg from "../../../img/fb-profile.jpg";
@@ -37,7 +37,6 @@ export const StyledDiv = styled.div`
 
 const MissionDetailsPage = ({
   mission,
-  requester,
   volunteerForMission,
   userUnverifiedPopupOpen,
   setUserUnverifiedPopupOpen,
@@ -59,30 +58,16 @@ const MissionDetailsPage = ({
       <Card>
         <Typography variant="h2">{mission.description}</Typography>
         <Box my={2}>
-          <Typography variant="h4">status: {mission.status}</Typography>
+          <Typography variant="h4">status: {missionStatusLabel[mission.status]}</Typography>
         </Box>
         <Grid>
           <Button text="Volunteer" onClick={volunteerForMission} />
         </Grid>
         <StyledHr />
 
-        <Box my={2}>
-          <Grid container wrap="nowrap" spacing={3} direction="row" alignItems="center">
-            <Grid item>
-              <Avatar alt={`${requester.name} Avatar Image`} src={profileImg} />
-            </Grid>
-            <Grid item>
-              <Typography variant="h4">{requester.name}</Typography>
-            </Grid>
-          </Grid>
-        </Box>
-        <Box my={1}>
-          <MapMarkerImg />
-          <Typography variant="h6">{requester.address}</Typography>
-        </Box>
         <Typography variant="body1">{mission.details}</Typography>
         <MapViewContainer>
-          {cords != undefined ? (
+          {cords !== undefined ? (
             <MapView values={cords} />
           ) : (
             <Typography>map: no valid location.</Typography>

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,3 +16,10 @@ export const colors = {
     color: "rgba(0, 0, 0, 0.2)",
   },
 };
+
+export const missionStatusLabel = {
+  todo: 'need volunteers',
+  doing: 'in progress',
+  done: 'done',
+  finished: 'finished',
+};


### PR DESCRIPTION
This pr removes the display of requester information from Mission Details and deletes associated hardcoded demo data.  Closes #180 

Also,  I noticed that the mission status display was not being converted to the display friendly label like it is on the Mission Card so I updated that as well (eg. 'todo' => 'needs volunteers')


Before:

![Screen Shot 2020-04-09 at 6 12 32 PM](https://user-images.githubusercontent.com/19916961/78954341-b17f2300-7a90-11ea-88e0-162796acddc5.png)


After:
![Screen Shot 2020-04-09 at 6 39 01 PM](https://user-images.githubusercontent.com/19916961/78954586-6dd8e900-7a91-11ea-9e55-9f003a817d7b.png)
