### PR TITLE
Update 'join our slack' link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The feature branch workflow is explained in more detail [by Atlassian here].
 [pr]: https://github.com/factn/resilience-app/compare
 [by Atlassian here]: https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow
 [readme]: https://github.com/factn/resilience-app/blob/master/README.md
-[join our slack]: https://join.slack.com/t/coronadonor/shared_invite/zt-cwm4b79c-12NHPqGWbzZ1aR5geyME1g
+[join our slack]: https://bit.ly/join_mutualaid_slack
 
 ## Branch naming conventions
 


### PR DESCRIPTION
Pointing all 'join our slack' links to point to https://bit.ly/join_mutualaid_slack so there is one central place to update when we need to update the linl.