### PR TITLE
Resolve page content shifting bug on /dashboard

### DIFF
--- a/src/app/dashboard/Appbar.jsx
+++ b/src/app/dashboard/Appbar.jsx
@@ -31,10 +31,10 @@ const useStyles = makeStyles((theme) => ({
     }),
   },
   menuButton: {
-    marginLeft: "4px",
+    marginLeft: theme.spacing(0.5),
   },
   toolBarTitle: {
-    marginLeft: "1rem",
+    marginLeft: theme.spacing(2),
   },
   hide: {
     display: "none",

--- a/src/app/dashboard/Appbar.jsx
+++ b/src/app/dashboard/Appbar.jsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles((theme) => ({
   menuButton: {
     marginLeft: "4px",
   },
+  toolBarTitle: {
+    marginLeft: "1rem",
+  },
   hide: {
     display: "none",
   },
@@ -61,7 +64,7 @@ export default function Appbar({ open, handleDrawerOpen }) {
         >
           <MenuIcon />
         </IconButton>
-        <Typography variant="h1" noWrap>
+        <Typography variant="h1" noWrap className={classes.toolBarTitle}>
           Missions Control
         </Typography>
       </Toolbar>

--- a/src/app/dashboard/Home/Overview.jsx
+++ b/src/app/dashboard/Home/Overview.jsx
@@ -25,13 +25,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Overview = ({ missions }) => {
+const Overview = ({ missions, className }) => {
   const classes = useStyles();
   const missionsNotStarted = Mission.filterByStatus(missions, "notStarted");
   const missionsQueued = Mission.filterByStatus(missions, "queued");
 
   return (
-    <Grid container direction="column" spacing={2}>
+    <Grid container direction="column" spacing={2} className={className}>
       <Grid item style={{ alignSelf: "flex-start" }}>
         <H2>Overview</H2>
       </Grid>

--- a/src/app/dashboard/MissionsControl.jsx
+++ b/src/app/dashboard/MissionsControl.jsx
@@ -29,10 +29,10 @@ const useStyles = makeStyles((theme) => ({
   pageContentShift: {
     marginLeft: drawerWidth,
     width: `calc(100% - ${drawerWidth}px)`,
-    padding: "4rem 0 0 0 !important",
+    padding: `${theme.spacing(5, 0, 0, 0)} !important`,
   },
   pageContent: {
-    padding: "4rem 0 0 4rem",
+    padding: theme.spacing(5, 0, 0, 7),
     transition: theme.transitions.create(["width", "padding", "padding-left"], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/app/dashboard/MissionsControl.jsx
+++ b/src/app/dashboard/MissionsControl.jsx
@@ -18,13 +18,25 @@ import PeopleIcon from "@material-ui/icons/People";
 import PanToolIcon from "@material-ui/icons/PanTool";
 import GetAppRoundedIcon from "@material-ui/icons/GetAppRounded";
 
+const drawerWidth = 240;
+
 const useStyles = makeStyles((theme) => ({
   root: {
     // the padding accounted for left menu and top header
     padding: theme.spacing(2),
-    paddingLeft: 73 + theme.spacing(2),
-    paddingTop: 64 + theme.spacing(2),
     width: "100%",
+  },
+  pageContentShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    padding: "4rem 0 0 0 !important",
+  },
+  pageContent: {
+    padding: "4rem 0 0 4rem",
+    transition: theme.transitions.create(["width", "padding", "padding-left"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
   },
 }));
 
@@ -86,7 +98,12 @@ const MissionsPage = ({ history }) => {
       />
       <Switch>
         <Route path="/dashboard/missions" component={Missions} />
-        <Route path="/dashboard/" component={Home} />
+        <Route
+          path="/dashboard/"
+          component={() => (
+            <Home className={`${open && classes.pageContentShift} ${classes.pageContent}`} />
+          )}
+        />
       </Switch>
     </div>
   );


### PR DESCRIPTION
https://github.com/factn/resilience-app/issues/216

On /dashboard, main page content would not shift to the right when the Drawer menu is open.
Resolved by passing className as a prop to the Home component that updates when the drawer "open" state variable is changed to shift the content to the right.