### PR TITLE
Update initial tab state for Signup

### DIFF
--- a/src/app/page/Signup/SignupScene.jsx
+++ b/src/app/page/Signup/SignupScene.jsx
@@ -37,7 +37,7 @@ const convertFullName = (fullName) => {
  */
 function SignupScene(props) {
   const { handleChange, values } = useForm();
-  const [activeTab, setActiveTab] = useState(2); // CHANGE ME!
+  const [activeTab, setActiveTab] = useState(0);
 
   function changeFormValues(changes) {
     for (const change of changes) {


### PR DESCRIPTION
I just noticed that the initial activeTab for the Signup process is being initialized with 2 when it should be 0.  I had set it to 2 during development and forgot to set it back for the pr.