### PR TITLE
Dashboard data optimization. Make MissionDetailsCard Stateless

### DIFF
--- a/src/app/dashboard/Missions/DashboardMissions.jsx
+++ b/src/app/dashboard/Missions/DashboardMissions.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import { Button } from "../../component";
@@ -133,15 +133,24 @@ const PageButtons = ({ classes, pageView, setPageView }) => {
 
 const DashboardMissions = ({ inDone, inPlanning, inProgress, inProposed }) => {
   const classes = useStyles();
-  const all = { inProposed, inPlanning, inProgress, inDone };
 
   const [pageView, setPageView] = useState(pageViews.list);
-  let filtered = inProposed;
+  const [selectedMission, setSelectedMission] = useState(null);
 
+  const all = { inProposed, inPlanning, inProgress, inDone };
   const viewFromUrl = _.getQueryParam("view");
-  filtered = all[viewFromUrl];
+  const filtered = all[viewFromUrl] || inProposed;
 
-  let selectedMissionId = _.getQueryParam("missionId");
+  const selectedMissionId = _.getQueryParam("missionId");
+
+  useEffect(() => {
+    if (selectedMissionId) {
+      const mission = filtered.find((m) => m.id === selectedMissionId);
+      mission && setSelectedMission(mission);
+    } else {
+      setSelectedMission(null);
+    }
+  }, [selectedMissionId, filtered]);
 
   return (
     <Grid container className={classes.root}>
@@ -160,7 +169,7 @@ const DashboardMissions = ({ inDone, inPlanning, inProgress, inProposed }) => {
           )}
         </Grid>
       </Grid>
-      {selectedMissionId && <MissionDetails missionId={selectedMissionId} />}
+      {selectedMission && <MissionDetails mission={selectedMission} />}
     </Grid>
   );
 };

--- a/src/app/dashboard/Missions/MissionDetails.jsx
+++ b/src/app/dashboard/Missions/MissionDetails.jsx
@@ -1,8 +1,5 @@
 import React from "react";
 import _ from "../../utils/lodash";
-import { connect } from "react-redux";
-import { firestoreConnect } from "react-redux-firebase";
-import { compose } from "recompose";
 
 import { H5, Body2 } from "../../component";
 import Button from "../../component/Button";
@@ -16,6 +13,7 @@ import AttachMoneyIcon from "@material-ui/icons/AttachMoney";
 
 import { makeStyles } from "@material-ui/core/styles";
 import { isLoaded, isEmpty } from "react-redux-firebase";
+import { useHistory } from "react-router-dom";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -82,9 +80,14 @@ const RowBody = ({ classes, content, Icon }) => {
  *
  * @component
  */
-const MissionDetailsCard = ({ mission, setselectedMissionId }) => {
+const MissionDetailsCard = ({ mission }) => {
   const classes = useStyles();
   const recipientPhoneNumber = _.get(mission, "recipientPhoneNumber");
+  const history = useHistory();
+  const clear = () =>
+    history.replace({
+      search: _.setQueryParam("missionId", ""),
+    });
 
   if (isLoaded(mission) && isEmpty(mission)) {
     return null;
@@ -93,7 +96,7 @@ const MissionDetailsCard = ({ mission, setselectedMissionId }) => {
     <Grid item xs={3}>
       <Paper className={classes.root} elevation={0}>
         <Grid container direction="row-reverse">
-          <Button onClick={() => setselectedMissionId(null)} variant="text">
+          <Button onClick={clear} variant="text">
             <CloseIcon />
           </Button>
         </Grid>
@@ -156,17 +159,4 @@ const MissionDetailsCard = ({ mission, setselectedMissionId }) => {
   );
 };
 
-const mapStateToProps = (state, ownProps) => {
-  let missions = state.firestore.data.missions || {};
-  return {
-    user: state.firebase.auth,
-    mission: missions[ownProps.missionId],
-  };
-};
-
-export default compose(
-  connect(mapStateToProps),
-  firestoreConnect((props) => {
-    return [{ collection: "missions", doc: props.missionId }];
-  })
-)(MissionDetailsCard);
+export default MissionDetailsCard;


### PR DESCRIPTION
We already have all the missions loaded in the dashboard. no reason to fetch one again when we open a details card.
Pr sends mission object directly to component now instead of grabbing it from firestore again