### PR TITLE
Inherit type styles instead of hard code

### DIFF
--- a/src/app/component/Typography.jsx
+++ b/src/app/component/Typography.jsx
@@ -3,37 +3,37 @@ import { Typography } from "@material-ui/core";
 import theme from "../../theme";
 
 const H1 = ({ children, ...rest }) => (
-  <Typography variant="h1" style={theme.typography.h1} {...rest}>
+  <Typography variant="h1" {...rest}>
     {children}{" "}
   </Typography>
 );
 const H2 = ({ children, ...rest }) => (
-  <Typography variant="h2" style={theme.typography.h2} {...rest}>
+  <Typography variant="h2" {...rest}>
     {children}
   </Typography>
 );
 const H3 = ({ children, ...rest }) => (
-  <Typography variant="h3" style={theme.typography.h3} {...rest}>
+  <Typography variant="h3" {...rest}>
     {children}{" "}
   </Typography>
 );
 const H4 = ({ children, ...rest }) => (
-  <Typography variant="h4" style={theme.typography.h4} {...rest}>
+  <Typography variant="h4" {...rest}>
     {children}{" "}
   </Typography>
 );
 const H5 = ({ children, ...rest }) => (
-  <Typography variant="h5" style={theme.typography.h5} {...rest}>
+  <Typography variant="h5" {...rest}>
     {children}{" "}
   </Typography>
 );
 const Body1 = ({ children, ...rest }) => (
-  <Typography variant="body1" style={theme.typography.body1} {...rest}>
+  <Typography variant="body1" {...rest}>
     {children}{" "}
   </Typography>
 );
 const Body2 = ({ children, ...rest }) => (
-  <Typography variant="body2" style={theme.typography.body2} {...rest}>
+  <Typography variant="body2" {...rest}>
     {children}{" "}
   </Typography>
 );


### PR DESCRIPTION
Can't overwrite styles easily with the current setup cause they're hard coded into the component.
Just let them naturally inherit it from the theme provider.