### PR TITLE
Snackbar storybook

### DIFF
--- a/src/app/component/Snackbars/ErrorSnackbar.jsx
+++ b/src/app/component/Snackbars/ErrorSnackbar.jsx
@@ -7,7 +7,11 @@ function Alert(props) {
   return <MuiAlert elevation={6} variant="filled" {...props} />;
 }
 
+/**
+ * @deprecated SuccessSnackbar has been combined with ErrorSnackbar in Snackbar
+ */
 function ErrorSnackbar({ autoHideDuration, errorMessage, handleClose, open }) {
+  console.warn("Deprecation warning: ErrorSnackbar has been deprecated for Snackbar");
   return (
     <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
       <Alert onClose={handleClose} severity="error">
@@ -24,7 +28,7 @@ ErrorSnackbar.propTypes = {
   errorMessage: PropTypes.string,
 };
 
-ErrorSnackbar.default = {
+ErrorSnackbar.defaultProps = {
   autoHideDuration: 4000,
 };
 

--- a/src/app/component/Snackbars/Snackbar.js
+++ b/src/app/component/Snackbars/Snackbar.js
@@ -1,0 +1,33 @@
+import MUISnackbar from "@material-ui/core/Snackbar";
+import MuiAlert from "@material-ui/lab/Alert";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Alert = (props) => {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+};
+
+const Snackbar = ({ autoHideDuration, handleClose, message, open, type }) => {
+  return (
+    <MUISnackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
+      <Alert onClose={handleClose} severity={type}>
+        {message}
+      </Alert>
+    </MUISnackbar>
+  );
+};
+
+Snackbar.propTypes = {
+  autoHideDuration: PropTypes.number,
+  message: PropTypes.string,
+  handleClose: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+  type: PropTypes.oneOf("success", "error"),
+};
+
+Snackbar.defaultProps = {
+  open: false,
+  autoHideDuration: 4000,
+};
+
+export default Snackbar;

--- a/src/app/component/Snackbars/Snackbar.stories.js
+++ b/src/app/component/Snackbars/Snackbar.stories.js
@@ -1,0 +1,63 @@
+import { Button } from "../../component";
+import { storiesOf } from "@storybook/react";
+import React, { useState } from "react";
+
+import Snackbar from "./Snackbar";
+
+storiesOf("Snackbars", module).add("Success", () => {
+  const [open, setOpen] = useState(false);
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <h2>Success</h2>
+
+      <Button onClick={handleOpen}>Open</Button>
+      <Button variant="outlined" onClick={handleClose}>
+        Close
+      </Button>
+
+      <Snackbar
+        handleClose={handleClose}
+        message="This is a success message."
+        open={open}
+        type="success"
+      />
+    </>
+  );
+});
+
+storiesOf("Snackbars", module).add("Error", () => {
+  const [open, setOpen] = useState(false);
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <h2>Error</h2>
+
+      <Button onClick={handleOpen}>Open</Button>
+      <Button variant="outlined" onClick={handleClose}>
+        Close
+      </Button>
+
+      <Snackbar
+        handleClose={handleClose}
+        message="This is an error message."
+        open={open}
+        type="error"
+      />
+    </>
+  );
+});

--- a/src/app/component/Snackbars/SuccessSnackbar.jsx
+++ b/src/app/component/Snackbars/SuccessSnackbar.jsx
@@ -7,8 +7,12 @@ function Alert(props) {
   return <MuiAlert elevation={6} variant="filled" {...props} />;
 }
 
+/**
+ * @deprecated SuccessSnackbar has been combined with ErrorSnackbar in Snackbar
+ */
 export default function SuccessSnackbar(props) {
   const { autoHideDuration, handleClose, open, successMessage } = props;
+  console.warn("Deprecation warning: SuccessSnackbar has been deprecated for Snackbar");
   return (
     <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
       <Alert onClose={handleClose} severity="success">
@@ -26,6 +30,6 @@ SuccessSnackbar.propTypes = {
   errorMessage: PropTypes.string,
 };
 
-SuccessSnackbar.default = {
+SuccessSnackbar.defaultProps = {
   autoHideDuration: 4000,
 };


### PR DESCRIPTION
Added a consolidated snackbar component, added deprecated annotations for SuccessSnackbar and ErrorSnackbar. We should use just <Snackbar /> moving forward

Example:

```javascript
      <Snackbar
        handleClose={() => ())}
        message="This is an error message."
        open={true}
        type="error"
      />
```