### PR TITLE
further fixes #298

### DIFF
--- a/src/app/page/MissionCreate/MissionForm.js
+++ b/src/app/page/MissionCreate/MissionForm.js
@@ -175,7 +175,6 @@ function MissionForm({ getFile, handleChange, onSubmit, values /*, assignHelper,
               apiKey: ANGOLIA_API_KEY,
               language: "en",
               countries: ["us"],
-              type: "city",
               // Other options from https://community.algolia.com/places/documentation.html#options
             }}
             onChange={(query) => handleLocation(query, "pickUp")}
@@ -218,7 +217,6 @@ function MissionForm({ getFile, handleChange, onSubmit, values /*, assignHelper,
               apiKey: ANGOLIA_API_KEY,
               language: "en",
               countries: ["us"],
-              type: "city",
               // Other options from https://community.algolia.com/places/documentation.html#options
             }}
             onChange={(query) => handleLocation(query, "dropOff")}


### PR DESCRIPTION
@Eihcir0 noted on the discussion for #298 that the location API was set to use cities and changed the AddressInput component in #311 to reflect the fix for that. 

This PR add the same fix as the city option still exists in MissionForm.js after #306 