### PR TITLE
Algolia API Keys

### DIFF
--- a/src/app/component/AddressInput/AddressInput.jsx
+++ b/src/app/component/AddressInput/AddressInput.jsx
@@ -2,7 +2,7 @@ import AlgoliaPlaces from "algolia-places-react";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { ANGOLIA_API_KEY } from "../../../constants";
+const { ALGOLIA_API_KEY, ALGOLIA_APP_ID } = process.env;
 
 const AddressInput = (props) => {
   const { placeholder, setStage, stage } = props;
@@ -26,8 +26,8 @@ const AddressInput = (props) => {
       placeholder={placeholder || "Search address"}
       name={stage}
       options={{
-        appId: "plZ318O8ODTC",
-        apiKey: ANGOLIA_API_KEY, // only 1k per day
+        appId: ALGOLIA_APP_ID,
+        apiKey: ALGOLIA_API_KEY,
         language: "en",
         countries: ["us"], // we have to support more countries in the future
         // Other options from https://community.algolia.com/places/documentation.html#options

--- a/src/app/page/MissionCreate/MissionForm.js
+++ b/src/app/page/MissionCreate/MissionForm.js
@@ -5,11 +5,12 @@ import AlgoliaPlaces from "algolia-places-react";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { ANGOLIA_API_KEY } from "../../../constants";
 import Button from "../../component/Button";
 import { Page } from "../../layout";
 import KeyDatePickerContainer from "./KeyDatePickerContainer";
 import { Upload, useStyles } from "./Request.style";
+
+const { ALGOLIA_API_KEY, ALGOLIA_APP_ID } = process.env;
 
 const StyledHeader = withStyles({
   root: {
@@ -171,8 +172,8 @@ function MissionForm({ getFile, handleChange, onSubmit, values /*, assignHelper,
             placeholder="Pickup location"
             name="pickUp"
             options={{
-              appId: "plZ318O8ODTC",
-              apiKey: ANGOLIA_API_KEY,
+              appId: ALGOLIA_APP_ID,
+              apiKey: ALGOLIA_API_KEY,
               language: "en",
               countries: ["us"],
               // Other options from https://community.algolia.com/places/documentation.html#options
@@ -213,11 +214,10 @@ function MissionForm({ getFile, handleChange, onSubmit, values /*, assignHelper,
             placeholder="Drop-off location"
             name="dropOff"
             options={{
-              appId: "plZ318O8ODTC",
-              apiKey: ANGOLIA_API_KEY,
+              appId: ALGOLIA_APP_ID,
+              apiKey: ALGOLIA_API_KEY,
               language: "en",
               countries: ["us"],
-              // Other options from https://community.algolia.com/places/documentation.html#options
             }}
             onChange={(query) => handleLocation(query, "dropOff")}
             onLimit={({ message }) =>

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,8 +17,6 @@ export const colors = {
   },
 };
 
-export const ANGOLIA_API_KEY = "b5e0781d289a9aa8edb37bf24aef874e";
-
 export const missionStatusLabel = {
   todo: "need volunteers",
   assigned: "assigned",


### PR DESCRIPTION
fixes #328 - Re-generated algolia API keys and APP ID. New values are pulled from `process.env`