### PR TITLE
Add ie support to create-react-app in development browser support in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
       "not op_mini all"
     ],
     "development": [
+      "ie 11",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"


### PR DESCRIPTION
IE support has been added to the Browserlist development section in this PR. Relates to issue #339 