### PR TITLE
Add react-app polyfill for ie9 and ie11 into index.tsx, patching last fix for ie support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mui-datatables": "^2.14.0",
     "path": "^0.12.7",
     "react": "^16.13.1",
+    "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-facebook-login": "^4.1.1",
     "react-firebaseui": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
       "not op_mini all"
     ],
     "development": [
+      "ie 11",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
 // If you enabled Analytics in your project, add the Firebase SDK for Analytics
+import 'react-app-polyfill/ie9';
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
 import "firebase/analytics";
 import "firebase/auth";
 import "firebase/firestore";


### PR DESCRIPTION
This PR fixes compatibility issues with IE11, allowing the application to run on the browser.
Relates to issue #339 and closed PR #340 