### PR TITLE
Feat/144/145 validation

### DIFF
--- a/src/app/model/User.ts
+++ b/src/app/model/User.ts
@@ -58,13 +58,20 @@ class User extends BaseModel {
   }
   /**
    * create a user
-   * @param {string} userUid - user
+   * @param {string | null} userUid - user
    * @param {object} data- updated data
+   * @returns {string} userUid - return back given uid or the generated new one
    */
-  createProfile(userUid: string, data: object) {
-    return this.getCollection("users")
-      .doc(userUid)
-      .set(this.load({ data, uid: userUid }));
+  createProfile(userUid: string | null, data: object) {
+    if (userUid) {
+      return this.getCollection("users")
+        .doc(userUid)
+        .set(this.load({ ...data, uid: userUid }))
+        .then(() => userUid);
+    }
+
+    const ref = this.getCollection("users").doc();
+    return ref.set(this.load({ ...data, uid: ref.id })).then(() => ref.id);
   }
 
   /**

--- a/src/app/page/Request/foodbox/ConfirmStep.jsx
+++ b/src/app/page/Request/foodbox/ConfirmStep.jsx
@@ -47,7 +47,6 @@ const useStyles = makeStyles((theme) => ({
 function ConfirmStep({ dispatch, state }) {
   const history = useHistory();
   const classes = useStyles();
-  const user = useSelector((state) => state.firebase.auth);
 
   const { cart } = state;
 
@@ -60,15 +59,15 @@ function ConfirmStep({ dispatch, state }) {
 
   // TODO we should try to create this mission before paying and if payment fails we delete it or something
   async function confirmRequest() {
-    const { cart } = state;
+    const { cart, instructions, location, recipient } = state;
     let mission = {
       type: MissionType.foodbox,
       status: MissionStatus.unassigned,
-      recipientUid: user.uid,
-      recipientDisplayName: user.displayName,
-      recipientPhoneNumber: user.phoneNumber,
-      deliveryLocation: state.location,
-      deliveryNotes: state.instructions,
+      recipientUid: recipient.uid,
+      recipientDisplayName: recipient.displayName,
+      recipientPhoneNumber: recipient.phoneNumber,
+      deliveryLocation: location,
+      deliveryNotes: instructions,
       missionDetails: {
         // TODO we should make use of the whole resource here instead of just the name
         needs: Object.keys(cart).map((key) => ({
@@ -77,7 +76,6 @@ function ConfirmStep({ dispatch, state }) {
         })),
       },
     };
-    console.log(mission);
 
     if (isDonationRequest) {
       mission = { ...mission, fundedStatus: MissionFundedStatus.notfunded };
@@ -97,7 +95,6 @@ function ConfirmStep({ dispatch, state }) {
       const redirect = isDonationRequest ? "donation" : "payment";
       history.push(`/request/foodbox/success/${redirect}`);
     } catch (error) {
-      console.log(error);
       dispatch({
         type: "ERROR",
         payload: "There was an error creating your mission. Please contact the organization.",

--- a/src/app/page/Request/foodbox/FoodboxStep.jsx
+++ b/src/app/page/Request/foodbox/FoodboxStep.jsx
@@ -18,9 +18,16 @@ function FoodboxStep({ dispatch, state }) {
     // We only need to do this once to get the initial foodboxes
     if (Object.keys(cart).length < 1) {
       // only using first box for now
-      Organization.getFoodBoxes().then((boxes) =>
-        dispatch({ type: "UPDATE_CART", payload: { resource: boxes[0], quantity: 1 } })
-      );
+      Organization.getFoodBoxes().then((boxes) => {
+        if (boxes.length > 0) {
+          dispatch({ type: "UPDATE_CART", payload: { resource: boxes[0], quantity: 1 } });
+        } else {
+          dispatch({
+            type: "ERROR",
+            payload: "We're sorry, there are no foodboxes available at this time.",
+          });
+        }
+      });
     }
   }, [cart, dispatch]);
 

--- a/src/app/page/Request/foodbox/reducer.ts
+++ b/src/app/page/Request/foodbox/reducer.ts
@@ -9,6 +9,11 @@ export type State = {
   cart: Record<string, CartItem>;
   instructions: string;
   location: Location | null;
+  recipient: {
+    displayName: string;
+    phoneNumber: string;
+    uid: string;
+  };
   step: 0 | 1 | 2;
   maxStep: 0 | 1 | 2;
   loading: boolean;
@@ -19,6 +24,11 @@ export const initialState: State = {
   cart: {},
   instructions: "",
   location: null,
+  recipient: {
+    displayName: "",
+    phoneNumber: "",
+    uid: "",
+  },
   step: 0,
   maxStep: 0,
   loading: false,
@@ -33,6 +43,11 @@ type ActionUpdateCart = {
 type Details = {
   location: Location;
   instructions: string;
+  recipient: {
+    displayName: string;
+    phoneNumber: string;
+    uid: string;
+  };
 };
 
 type ActionUpdateDetails = {
@@ -82,8 +97,8 @@ export function reducer(state: State, { payload, type }: Actions) {
       newCart[resource.uid] = { resource, quantity };
       return { ...state, cart: newCart };
     case "UPDATE_DETAILS":
-      const { instructions, location } = payload as Details;
-      return { ...state, instructions, location, step: 2, maxStep: 2 };
+      const { instructions, location, recipient } = payload as Details;
+      return { ...state, instructions, location, recipient, step: 2, maxStep: 2 };
     case "UPDATE_STEP":
       // make sure we're only going to a step less than or equal to the max step
       return { ...state, step: payload && payload <= state.maxStep ? payload : state.step };


### PR DESCRIPTION
closes #433
closes #432 

Adding more validation to make sure we have the right info before creating a mission.
@mat10tng I know we talked about making a validation method but this ended being better for this usecase as we're just validating the user info needed and it can be done before going to the confirm page so we can prevent user going there all together if they don't have the right info.

This PR also handles when a user cannot receive SMS
- we now create a user that isn't hooked to any login but at least store the persons contact info and name
- maybe we want to enable email logins for this use case??

Also now handling the scenario when a user has signed up via social but hasn't given a phone number
- if there is no number attached to account we prompt them with the same phone number form as the logged out user and link it