### PR TITLE
Date time input

### DIFF
--- a/src/app/component/DateTimeInput/DateTimeInput.jsx
+++ b/src/app/component/DateTimeInput/DateTimeInput.jsx
@@ -29,6 +29,13 @@ const DateTimeInput = ({ dateInputProps, onChange, required, timeInputProps, val
     ...dateInputProps,
   };
 
+  const timePickerProps = {
+    id: "datetime-input-time",
+    label: "Time",
+    margin: "normal",
+    ...timeInputProps,
+  };
+
   return (
     <MuiPickersUtilsProvider utils={MomentUtils}>
       <KeyDatePickerContainer
@@ -47,7 +54,7 @@ const DateTimeInput = ({ dateInputProps, onChange, required, timeInputProps, val
         required={required}
         onChange={(val) => handleChange("time", val)}
         KeyboardButtonProps={{ "aria-label": "change time" }}
-        {...timeInputProps}
+        {...timePickerProps}
       />
     </MuiPickersUtilsProvider>
   );

--- a/src/app/component/DateTimeInput/DateTimeInput.jsx
+++ b/src/app/component/DateTimeInput/DateTimeInput.jsx
@@ -1,0 +1,66 @@
+import MomentUtils from "@date-io/date-fns";
+import { KeyboardTimePicker, MuiPickersUtilsProvider } from "@material-ui/pickers";
+import KeyDatePickerContainer from "../../page/MissionCreate/KeyDatePickerContainer";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * Wrapper component for KeybardDatePickerContainer and KeyboadTimePicker
+ * which accepts a value object that has 'time' and 'date' props and will
+ * update that object via the onChange handler
+ * @function
+ * @param {object} dateInputProps
+ * @param {object} timeInputProps
+ * @param {string} value
+ * @param {func} onChange
+ */
+const DateTimeInput = ({ dateInputProps, onChange, required, timeInputProps, value }) => {
+  const handleChange = (field, newValue) => {
+    onChange({
+      ...value,
+      [field]: newValue,
+    });
+  };
+
+  const datePickerContainerProps = {
+    id: "datetime-input-date",
+    label: "Date",
+    margin: "normal",
+    ...dateInputProps,
+  };
+
+  return (
+    <MuiPickersUtilsProvider utils={MomentUtils}>
+      <KeyDatePickerContainer
+        onChange={(val) => handleChange("date", val)}
+        required={required}
+        value={value.date}
+        margin="normal"
+        format="MM/dd/yyyy"
+        KeyboardButtonProps={{
+          "aria-label": "change date",
+        }}
+        {...datePickerContainerProps}
+      />
+      <KeyboardTimePicker
+        value={value.time}
+        required={required}
+        onChange={(val) => handleChange("time", val)}
+        KeyboardButtonProps={{ "aria-label": "change time" }}
+        {...timeInputProps}
+      />
+    </MuiPickersUtilsProvider>
+  );
+};
+
+DateTimeInput.propTypes = {
+  dateInputProps: PropTypes.object,
+  timeInputProps: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.shape({
+    time: PropTypes.object,
+    date: PropTypes.object,
+  }).isRequired, // Strict shape not enforced, object can contain other properties (like 'location')
+};
+
+export default DateTimeInput;

--- a/src/app/component/DateTimeInput/index.js
+++ b/src/app/component/DateTimeInput/index.js
@@ -1,0 +1,2 @@
+import DateTimeInput from "./DateTimeInput";
+export default DateTimeInput;

--- a/src/app/page/MissionCreate/KeyDatePickerContainer.js
+++ b/src/app/page/MissionCreate/KeyDatePickerContainer.js
@@ -55,8 +55,8 @@ KeyDatePickerContainer.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   margin: PropTypes.string.isRequired,
-  onChange: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.object.isRequired,
 };
 
 export default KeyDatePickerContainer;


### PR DESCRIPTION
This pr creates new `DateTimeInput` component which wraps _KeyboardTimePicker_ (material-ui) and our _KeyDatePickerContainer_ -- a wrapper around _KeyboardDatePicker_ (material-ui)

I needed this in Mission edit and I saw that we were using this logic in MissionForm so I created this reusable component to be used by both.  

The next pr (dependent upon this one) plugs this component into the MissionForm (create) and then a subsequent pr after that will see this used in the MissionEditForm