### PR TITLE
lower cache-control setting for root '/' page (aka index.html) only

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -28,7 +28,14 @@
         "source": "**",
         "destination": "/index.html"
       }
-    ]
+    ],
+    "headers": [  {
+      "source": "/",
+      "headers": [ {
+        "key": "Cache-Control",
+        "value": "max-age=300"
+      } ]
+    } ]
   },
   "emulators": {
     "functions": {


### PR DESCRIPTION
Tiny change to allow lower cache control setting to 5 mins for the root page only. 

cf. https://www.giftofspeed.com/cache-checker/

Before:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/166867/82121462-518f4100-97e1-11ea-9094-0a2b92516f11.png">

After:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/166867/82121469-59e77c00-97e1-11ea-9982-8e002a6b5153.png">

