### PR TITLE
Fix 550 and details object

### DIFF
--- a/scheme/data.json
+++ b/scheme/data.json
@@ -51,7 +51,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028579",
+          "createdDate": "2020-05-17T18:58:28.828737",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -68,7 +68,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.028600"
+            "startTime": "2020-05-17T18:58:28.828764"
           },
           "pickUpLocation": {
             "address": "1012 N Mariposa Ave #911, Los Angeles, CA 90029, USA",
@@ -79,7 +79,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.028609"
+            "startTime": "2020-05-17T18:58:28.828772"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -108,7 +108,7 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 3,
               "type": "donationbox",
               "cost": "25",
@@ -123,7 +123,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028646",
+          "createdDate": "2020-05-17T18:58:28.828808",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -140,7 +140,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.028652"
+            "startTime": "2020-05-17T18:58:28.828813"
           },
           "pickUpLocation": {
             "address": "1813 Potomac Ave, Los Angeles, CA 90016, USA",
@@ -151,7 +151,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.028658"
+            "startTime": "2020-05-17T18:58:28.828819"
           },
           "deliveryLocation": {
             "address": "13932 Hubbard St, Sylmar, CA 91342, USA",
@@ -179,9 +179,9 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028685",
+          "createdDate": "2020-05-17T18:58:28.828844",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.028710",
+          "fundedDate": "2020-05-17T18:58:28.828867",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -196,7 +196,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.028690"
+            "startTime": "2020-05-17T18:58:28.828848"
           },
           "pickUpLocation": {
             "address": "1232 Queen Anne Pl, Los Angeles, CA 90019, USA",
@@ -207,7 +207,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.028697"
+            "startTime": "2020-05-17T18:58:28.828854"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -235,7 +235,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028745",
+          "createdDate": "2020-05-17T18:58:28.828899",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -252,7 +252,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.028750"
+            "startTime": "2020-05-17T18:58:28.828904"
           },
           "pickUpLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -263,7 +263,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.028756"
+            "startTime": "2020-05-17T18:58:28.828910"
           },
           "deliveryLocation": {
             "address": "12321 De Garmo Ave, Sylmar, CA 91342, USA",
@@ -307,9 +307,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028791",
+          "createdDate": "2020-05-17T18:58:28.828942",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.028816",
+          "fundedDate": "2020-05-17T18:58:28.828965",
           "readyToStart": false,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -324,7 +324,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.028796"
+            "startTime": "2020-05-17T18:58:28.828947"
           },
           "pickUpLocation": {
             "address": "5591 Monterey Rd, Los Angeles, CA 90042, USA",
@@ -335,7 +335,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.028805"
+            "startTime": "2020-05-17T18:58:28.828955"
           },
           "deliveryLocation": {
             "address": "2353 Thelma Ave, Los Angeles, CA 90032, USA",
@@ -371,7 +371,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028854",
+          "createdDate": "2020-05-17T18:58:28.829001",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -388,7 +388,7 @@
           "recipientPhoneNumber": "489.241.1578x1565",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.028859"
+            "startTime": "2020-05-17T18:58:28.829005"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -399,7 +399,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.028866"
+            "startTime": "2020-05-17T18:58:28.829012"
           },
           "deliveryLocation": {
             "address": "13123 Harps St, Sylmar, CA 91342, USA",
@@ -427,7 +427,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028894",
+          "createdDate": "2020-05-17T18:58:28.829038",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -444,7 +444,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.028900"
+            "startTime": "2020-05-17T18:58:28.829043"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -455,7 +455,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.028906"
+            "startTime": "2020-05-17T18:58:28.829049"
           },
           "deliveryLocation": {
             "address": "802 N Normandie Ave, Los Angeles, CA 90029, USA",
@@ -491,9 +491,9 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.028940",
+          "createdDate": "2020-05-17T18:58:28.829080",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.028962",
+          "fundedDate": "2020-05-17T18:58:28.829101",
           "readyToStart": false,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -508,7 +508,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.028945"
+            "startTime": "2020-05-17T18:58:28.829085"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -519,7 +519,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.028951"
+            "startTime": "2020-05-17T18:58:28.829091"
           },
           "deliveryLocation": {
             "address": "3243 Farnsworth Ave, Los Angeles, CA 90032, USA",
@@ -547,7 +547,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029005",
+          "createdDate": "2020-05-17T18:58:28.829133",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -564,7 +564,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029010"
+            "startTime": "2020-05-17T18:58:28.829138"
           },
           "pickUpLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -575,7 +575,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029016"
+            "startTime": "2020-05-17T18:58:28.829143"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -596,7 +596,7 @@
           "details": [
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 3,
               "type": "donationbox",
               "cost": "25",
@@ -619,9 +619,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029046",
+          "createdDate": "2020-05-17T18:58:28.829172",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.029072",
+          "fundedDate": "2020-05-17T18:58:28.829197",
           "readyToStart": true,
           "groupUid": "Daly City 2020/05/05",
           "groupDisplayName": "Daly City 2020/05/05",
@@ -636,7 +636,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029051"
+            "startTime": "2020-05-17T18:58:28.829177"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -647,7 +647,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.029060"
+            "startTime": "2020-05-17T18:58:28.829185"
           },
           "deliveryLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -691,7 +691,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029111",
+          "createdDate": "2020-05-17T18:58:28.829235",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -708,7 +708,7 @@
           "recipientPhoneNumber": "947.196.5934x2320",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029116"
+            "startTime": "2020-05-17T18:58:28.829239"
           },
           "pickUpLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -719,7 +719,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029122"
+            "startTime": "2020-05-17T18:58:28.829245"
           },
           "deliveryLocation": {
             "address": "13123 Shenley St, Sylmar, CA 91342, USA",
@@ -747,7 +747,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029148",
+          "createdDate": "2020-05-17T18:58:28.829270",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -764,7 +764,7 @@
           "recipientPhoneNumber": "489.241.1578x1565",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029152"
+            "startTime": "2020-05-17T18:58:28.829274"
           },
           "pickUpLocation": {
             "address": "1165 1/2 N Kingsley Dr #1190, Los Angeles, CA 90029, USA",
@@ -775,7 +775,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.029158"
+            "startTime": "2020-05-17T18:58:28.829280"
           },
           "deliveryLocation": {
             "address": "2323 Thelma Ave, Los Angeles, CA 90032, USA",
@@ -796,14 +796,14 @@
           "details": [
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 3,
               "type": "donationbox",
               "cost": "25",
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029183",
+          "createdDate": "2020-05-17T18:58:28.829315",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -820,7 +820,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.029188"
+            "startTime": "2020-05-17T18:58:28.829319"
           },
           "pickUpLocation": {
             "address": "2393 Silver Ridge Ave, Los Angeles, CA 90039, USA",
@@ -831,7 +831,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029194"
+            "startTime": "2020-05-17T18:58:28.829325"
           },
           "deliveryLocation": {
             "address": "639 N Westmoreland Ave, Los Angeles, CA 90004, USA",
@@ -859,7 +859,7 @@
               "description": "8 or 9 types, like broccoli, celery and kale."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029220",
+          "createdDate": "2020-05-17T18:58:28.829360",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -876,7 +876,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029225"
+            "startTime": "2020-05-17T18:58:28.829365"
           },
           "pickUpLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -887,7 +887,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.029231"
+            "startTime": "2020-05-17T18:58:28.829371"
           },
           "deliveryLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -931,9 +931,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029264",
+          "createdDate": "2020-05-17T18:58:28.829403",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.029300",
+          "fundedDate": "2020-05-17T18:58:28.829425",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -948,7 +948,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029269"
+            "startTime": "2020-05-17T18:58:28.829407"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -959,7 +959,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.029289"
+            "startTime": "2020-05-17T18:58:28.829415"
           },
           "deliveryLocation": {
             "address": "3243 Farnsworth Ave, Los Angeles, CA 90032, USA",
@@ -1003,7 +1003,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029340",
+          "createdDate": "2020-05-17T18:58:28.829463",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1020,7 +1020,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029344"
+            "startTime": "2020-05-17T18:58:28.829467"
           },
           "pickUpLocation": {
             "address": "784 N Alexandria Ave, Los Angeles, CA 90029, USA",
@@ -1031,7 +1031,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029352"
+            "startTime": "2020-05-17T18:58:28.829475"
           },
           "deliveryLocation": {
             "address": "690 Imogen Ave #10, Los Angeles, CA 90026, USA",
@@ -1075,7 +1075,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029382",
+          "createdDate": "2020-05-17T18:58:28.829503",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1092,7 +1092,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029386"
+            "startTime": "2020-05-17T18:58:28.829507"
           },
           "pickUpLocation": {
             "address": "12321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -1103,7 +1103,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029392"
+            "startTime": "2020-05-17T18:58:28.829513"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -1147,7 +1147,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029422",
+          "createdDate": "2020-05-17T18:58:28.829541",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1164,7 +1164,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029427"
+            "startTime": "2020-05-17T18:58:28.829545"
           },
           "pickUpLocation": {
             "address": "2393 Silver Ridge Ave, Los Angeles, CA 90039, USA",
@@ -1175,7 +1175,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029432"
+            "startTime": "2020-05-17T18:58:28.829562"
           },
           "deliveryLocation": {
             "address": "639 N Westmoreland Ave, Los Angeles, CA 90004, USA",
@@ -1196,7 +1196,7 @@
           "details": [
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 2,
               "type": "donationbox",
               "cost": "25",
@@ -1211,9 +1211,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029463",
+          "createdDate": "2020-05-17T18:58:28.829591",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.029484",
+          "fundedDate": "2020-05-17T18:58:28.829634",
           "readyToStart": false,
           "groupUid": "Daly City 2020/05/05",
           "groupDisplayName": "Daly City 2020/05/05",
@@ -1228,7 +1228,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.029468"
+            "startTime": "2020-05-17T18:58:28.829607"
           },
           "pickUpLocation": {
             "address": "12321 De Garmo Ave, Sylmar, CA 91342, USA",
@@ -1239,7 +1239,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029474"
+            "startTime": "2020-05-17T18:58:28.829613"
           },
           "deliveryLocation": {
             "address": "4910 W Adams Blvd #1, Los Angeles, CA 90016, USA",
@@ -1267,7 +1267,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029521",
+          "createdDate": "2020-05-17T18:58:28.829680",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1284,7 +1284,7 @@
           "recipientPhoneNumber": "+1-891-013-9916x1510",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029526"
+            "startTime": "2020-05-17T18:58:28.829685"
           },
           "pickUpLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -1295,7 +1295,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029531"
+            "startTime": "2020-05-17T18:58:28.829691"
           },
           "deliveryLocation": {
             "address": "13321 Tripoli Ave, Sylmar, CA 91342, USA",
@@ -1331,7 +1331,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029561",
+          "createdDate": "2020-05-17T18:58:28.829731",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1348,7 +1348,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029566"
+            "startTime": "2020-05-17T18:58:28.829736"
           },
           "pickUpLocation": {
             "address": "1165 1/2 N Kingsley Dr #1190, Los Angeles, CA 90029, USA",
@@ -1359,7 +1359,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029572"
+            "startTime": "2020-05-17T18:58:28.829743"
           },
           "deliveryLocation": {
             "address": "4910 W Adams Blvd #1, Los Angeles, CA 90016, USA",
@@ -1403,7 +1403,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029604",
+          "createdDate": "2020-05-17T18:58:28.829777",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1420,7 +1420,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029609"
+            "startTime": "2020-05-17T18:58:28.829782"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -1431,7 +1431,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029617"
+            "startTime": "2020-05-17T18:58:28.829791"
           },
           "deliveryLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -1475,9 +1475,9 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029650",
+          "createdDate": "2020-05-17T18:58:28.829827",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.029671",
+          "fundedDate": "2020-05-17T18:58:28.829849",
           "readyToStart": true,
           "groupUid": null,
           "groupDisplayName": null,
@@ -1492,7 +1492,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029655"
+            "startTime": "2020-05-17T18:58:28.829832"
           },
           "pickUpLocation": {
             "address": "Tucker Ave, Los Angeles, CA 91342, USA",
@@ -1503,7 +1503,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029661"
+            "startTime": "2020-05-17T18:58:28.829838"
           },
           "deliveryLocation": {
             "address": "5545 Via Marisol, Los Angeles, CA 90042, USA",
@@ -1531,7 +1531,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029705",
+          "createdDate": "2020-05-17T18:58:28.829885",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1548,7 +1548,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029709"
+            "startTime": "2020-05-17T18:58:28.829890"
           },
           "pickUpLocation": {
             "address": "5322 Weaver St, Los Angeles, CA 90042, USA",
@@ -1559,7 +1559,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029715"
+            "startTime": "2020-05-17T18:58:28.829897"
           },
           "deliveryLocation": {
             "address": "13321 Pala Ave, Sylmar, CA 91342, USA",
@@ -1587,9 +1587,9 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029741",
+          "createdDate": "2020-05-17T18:58:28.829926",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.029762",
+          "fundedDate": "2020-05-17T18:58:28.829949",
           "readyToStart": true,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -1604,7 +1604,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.029746"
+            "startTime": "2020-05-17T18:58:28.829931"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -1615,7 +1615,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.029752"
+            "startTime": "2020-05-17T18:58:28.829937"
           },
           "deliveryLocation": {
             "address": "5545 Via Marisol, Los Angeles, CA 90042, USA",
@@ -1643,7 +1643,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029796",
+          "createdDate": "2020-05-17T18:58:28.829986",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1660,7 +1660,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.029801"
+            "startTime": "2020-05-17T18:58:28.829991"
           },
           "pickUpLocation": {
             "address": "13932 Hubbard St, Sylmar, CA 91342, USA",
@@ -1671,7 +1671,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029807"
+            "startTime": "2020-05-17T18:58:28.829997"
           },
           "deliveryLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -1715,7 +1715,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029842",
+          "createdDate": "2020-05-17T18:58:28.830034",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1732,7 +1732,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029846"
+            "startTime": "2020-05-17T18:58:28.830040"
           },
           "pickUpLocation": {
             "address": "13123 Harps St, Sylmar, CA 91342, USA",
@@ -1743,7 +1743,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.029852"
+            "startTime": "2020-05-17T18:58:28.830046"
           },
           "deliveryLocation": {
             "address": "743 1/2 N Heliotrope Dr #1010, Los Angeles, CA 90029, USA",
@@ -1772,7 +1772,7 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 3,
               "type": "donationbox",
               "cost": "25",
@@ -1787,7 +1787,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029886",
+          "createdDate": "2020-05-17T18:58:28.830084",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1804,7 +1804,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.029891"
+            "startTime": "2020-05-17T18:58:28.830089"
           },
           "pickUpLocation": {
             "address": "125 S Everett St #2, Glendale, CA 91205, USA",
@@ -1815,7 +1815,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029897"
+            "startTime": "2020-05-17T18:58:28.830095"
           },
           "deliveryLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -1852,14 +1852,14 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 3,
               "type": "donationbox",
               "cost": "25",
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029927",
+          "createdDate": "2020-05-17T18:58:28.830130",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1876,7 +1876,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029931"
+            "startTime": "2020-05-17T18:58:28.830135"
           },
           "pickUpLocation": {
             "address": "13321 Tripoli Ave, Sylmar, CA 91342, USA",
@@ -1887,7 +1887,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.029937"
+            "startTime": "2020-05-17T18:58:28.830142"
           },
           "deliveryLocation": {
             "address": "743 1/2 N Heliotrope Dr #1010, Los Angeles, CA 90029, USA",
@@ -1923,9 +1923,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.029983",
+          "createdDate": "2020-05-17T18:58:28.830176",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.030011",
+          "fundedDate": "2020-05-17T18:58:28.830199",
           "readyToStart": true,
           "groupUid": null,
           "groupDisplayName": null,
@@ -1940,7 +1940,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.029990"
+            "startTime": "2020-05-17T18:58:28.830181"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -1951,7 +1951,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.029998"
+            "startTime": "2020-05-17T18:58:28.830188"
           },
           "deliveryLocation": {
             "address": "802 N Normandie Ave, Los Angeles, CA 90029, USA",
@@ -1979,7 +1979,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030057",
+          "createdDate": "2020-05-17T18:58:28.830237",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1996,7 +1996,7 @@
           "recipientPhoneNumber": "+1-891-013-9916x1510",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030064"
+            "startTime": "2020-05-17T18:58:28.830243"
           },
           "pickUpLocation": {
             "address": "13321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2007,7 +2007,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030072"
+            "startTime": "2020-05-17T18:58:28.830250"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -2035,7 +2035,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030108",
+          "createdDate": "2020-05-17T18:58:28.830276",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2052,7 +2052,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030115"
+            "startTime": "2020-05-17T18:58:28.830281"
           },
           "pickUpLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -2063,7 +2063,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.030122"
+            "startTime": "2020-05-17T18:58:28.830287"
           },
           "deliveryLocation": {
             "address": "Tucker Ave, Los Angeles, CA 91342, USA",
@@ -2099,7 +2099,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030159",
+          "createdDate": "2020-05-17T18:58:28.830317",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -2116,7 +2116,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.030165"
+            "startTime": "2020-05-17T18:58:28.830321"
           },
           "pickUpLocation": {
             "address": "13321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2127,7 +2127,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030173"
+            "startTime": "2020-05-17T18:58:28.830328"
           },
           "deliveryLocation": {
             "address": "1813 Potomac Ave, Los Angeles, CA 90016, USA",
@@ -2156,14 +2156,14 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 2,
               "type": "donationbox",
               "cost": "25",
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030217",
+          "createdDate": "2020-05-17T18:58:28.830364",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2180,7 +2180,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.030224"
+            "startTime": "2020-05-17T18:58:28.830369"
           },
           "pickUpLocation": {
             "address": "912 Yoakum St, Los Angeles, CA 90032, USA",
@@ -2191,7 +2191,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.030231"
+            "startTime": "2020-05-17T18:58:28.830376"
           },
           "deliveryLocation": {
             "address": "12321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2219,7 +2219,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030266",
+          "createdDate": "2020-05-17T18:58:28.830404",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -2236,7 +2236,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.030272"
+            "startTime": "2020-05-17T18:58:28.830409"
           },
           "pickUpLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -2247,7 +2247,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.030280"
+            "startTime": "2020-05-17T18:58:28.830415"
           },
           "deliveryLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -2291,7 +2291,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030322",
+          "createdDate": "2020-05-17T18:58:28.830449",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2308,7 +2308,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-17T18:52:31.030328"
+            "startTime": "2020-05-17T18:58:28.830454"
           },
           "pickUpLocation": {
             "address": "13321 Pala Ave, Sylmar, CA 91342, USA",
@@ -2319,7 +2319,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.030336"
+            "startTime": "2020-05-17T18:58:28.830461"
           },
           "deliveryLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -2348,7 +2348,7 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 2,
               "type": "donationbox",
               "cost": "25",
@@ -2356,14 +2356,14 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 2,
               "type": "donationbox",
               "cost": "25",
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030376",
+          "createdDate": "2020-05-17T18:58:28.830493",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2380,7 +2380,7 @@
           "recipientPhoneNumber": "947.196.5934x2320",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-17T18:52:31.030382"
+            "startTime": "2020-05-17T18:58:28.830498"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -2391,7 +2391,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030389"
+            "startTime": "2020-05-17T18:58:28.830504"
           },
           "deliveryLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -2420,14 +2420,14 @@
             },
             {
               "resourceUid": "7",
-              "displayName": "Produce Box # 5: Donation Box",
+              "displayName": "Donate a box",
               "quantity": 2,
               "type": "donationbox",
               "cost": "25",
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030425",
+          "createdDate": "2020-05-17T18:58:28.830533",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2444,7 +2444,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-17T18:52:31.030432"
+            "startTime": "2020-05-17T18:58:28.830538"
           },
           "pickUpLocation": {
             "address": "14321 Rinaldi St, San Fernando, CA 91340, USA",
@@ -2455,7 +2455,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.030439"
+            "startTime": "2020-05-17T18:58:28.830545"
           },
           "deliveryLocation": {
             "address": "784 N Alexandria Ave, Los Angeles, CA 90029, USA",
@@ -2491,7 +2491,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030475",
+          "createdDate": "2020-05-17T18:58:28.830573",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2508,7 +2508,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.030480"
+            "startTime": "2020-05-17T18:58:28.830578"
           },
           "pickUpLocation": {
             "address": "690 Imogen Ave #10, Los Angeles, CA 90026, USA",
@@ -2519,7 +2519,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-17T18:52:31.030491"
+            "startTime": "2020-05-17T18:58:28.830586"
           },
           "deliveryLocation": {
             "address": "1014 N Mariposa Ave #110, Los Angeles, CA 90029, USA",
@@ -2547,9 +2547,9 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-17T18:52:31.030529",
+          "createdDate": "2020-05-17T18:58:28.830617",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-17T18:52:31.030556",
+          "fundedDate": "2020-05-17T18:58:28.830640",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -2564,7 +2564,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-17T18:52:31.030535"
+            "startTime": "2020-05-17T18:58:28.830623"
           },
           "pickUpLocation": {
             "address": "CA-2, California, USA",
@@ -2575,7 +2575,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-17T18:52:31.030543"
+            "startTime": "2020-05-17T18:58:28.830629"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -2640,7 +2640,7 @@
         },
         "7": {
           "uid": "7",
-          "displayName": "Produce Box # 5: Donation Box",
+          "displayName": "Donate a box",
           "cost": "25",
           "availableToOrder": true,
           "type": "donationbox",

--- a/scheme/data.json
+++ b/scheme/data.json
@@ -12,14 +12,12 @@
         "https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395"
       ],
       "contactPhoneNumber": "",
-      "location": [
-        {
-          "address": "Studio City, CA",
-          "label": "",
-          "lat": 34.1483989,
-          "lng": -118.3961877
-        }
-      ],
+      "location": {
+        "address": "Studio City, CA",
+        "label": "",
+        "lat": 34.1483989,
+        "lng": -118.3961877
+      },
       "localTimeZone": "",
       "phoneNumber": "+1-604-876-4759x38242",
       "EINNumber": "12-3456789",

--- a/scheme/data.json
+++ b/scheme/data.json
@@ -51,7 +51,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349055",
+          "createdDate": "2020-05-17T18:52:31.028579",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -68,7 +68,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.349108"
+            "startTime": "2020-05-17T18:52:31.028600"
           },
           "pickUpLocation": {
             "address": "1012 N Mariposa Ave #911, Los Angeles, CA 90029, USA",
@@ -79,7 +79,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349122"
+            "startTime": "2020-05-17T18:52:31.028609"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -123,7 +123,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349179",
+          "createdDate": "2020-05-17T18:52:31.028646",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -140,7 +140,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349186"
+            "startTime": "2020-05-17T18:52:31.028652"
           },
           "pickUpLocation": {
             "address": "1813 Potomac Ave, Los Angeles, CA 90016, USA",
@@ -151,7 +151,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349193"
+            "startTime": "2020-05-17T18:52:31.028658"
           },
           "deliveryLocation": {
             "address": "13932 Hubbard St, Sylmar, CA 91342, USA",
@@ -179,9 +179,9 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349224",
+          "createdDate": "2020-05-17T18:52:31.028685",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.349250",
+          "fundedDate": "2020-05-17T18:52:31.028710",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -196,7 +196,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349229"
+            "startTime": "2020-05-17T18:52:31.028690"
           },
           "pickUpLocation": {
             "address": "1232 Queen Anne Pl, Los Angeles, CA 90019, USA",
@@ -207,7 +207,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.349236"
+            "startTime": "2020-05-17T18:52:31.028697"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -235,7 +235,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349292",
+          "createdDate": "2020-05-17T18:52:31.028745",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -252,7 +252,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349298"
+            "startTime": "2020-05-17T18:52:31.028750"
           },
           "pickUpLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -263,7 +263,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.349304"
+            "startTime": "2020-05-17T18:52:31.028756"
           },
           "deliveryLocation": {
             "address": "12321 De Garmo Ave, Sylmar, CA 91342, USA",
@@ -307,9 +307,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349341",
+          "createdDate": "2020-05-17T18:52:31.028791",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.349364",
+          "fundedDate": "2020-05-17T18:52:31.028816",
           "readyToStart": false,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -324,7 +324,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349347"
+            "startTime": "2020-05-17T18:52:31.028796"
           },
           "pickUpLocation": {
             "address": "5591 Monterey Rd, Los Angeles, CA 90042, USA",
@@ -335,7 +335,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349353"
+            "startTime": "2020-05-17T18:52:31.028805"
           },
           "deliveryLocation": {
             "address": "2353 Thelma Ave, Los Angeles, CA 90032, USA",
@@ -371,7 +371,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349404",
+          "createdDate": "2020-05-17T18:52:31.028854",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -388,7 +388,7 @@
           "recipientPhoneNumber": "489.241.1578x1565",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.349409"
+            "startTime": "2020-05-17T18:52:31.028859"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -399,7 +399,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349416"
+            "startTime": "2020-05-17T18:52:31.028866"
           },
           "deliveryLocation": {
             "address": "13123 Harps St, Sylmar, CA 91342, USA",
@@ -427,7 +427,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349445",
+          "createdDate": "2020-05-17T18:52:31.028894",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -444,7 +444,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349450"
+            "startTime": "2020-05-17T18:52:31.028900"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -455,7 +455,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.349456"
+            "startTime": "2020-05-17T18:52:31.028906"
           },
           "deliveryLocation": {
             "address": "802 N Normandie Ave, Los Angeles, CA 90029, USA",
@@ -491,9 +491,9 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349489",
+          "createdDate": "2020-05-17T18:52:31.028940",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.349512",
+          "fundedDate": "2020-05-17T18:52:31.028962",
           "readyToStart": false,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -508,7 +508,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.349494"
+            "startTime": "2020-05-17T18:52:31.028945"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -519,7 +519,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349500"
+            "startTime": "2020-05-17T18:52:31.028951"
           },
           "deliveryLocation": {
             "address": "3243 Farnsworth Ave, Los Angeles, CA 90032, USA",
@@ -547,7 +547,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349546",
+          "createdDate": "2020-05-17T18:52:31.029005",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -564,7 +564,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349551"
+            "startTime": "2020-05-17T18:52:31.029010"
           },
           "pickUpLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -575,7 +575,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349557"
+            "startTime": "2020-05-17T18:52:31.029016"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -619,9 +619,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349587",
+          "createdDate": "2020-05-17T18:52:31.029046",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.349609",
+          "fundedDate": "2020-05-17T18:52:31.029072",
           "readyToStart": true,
           "groupUid": "Daly City 2020/05/05",
           "groupDisplayName": "Daly City 2020/05/05",
@@ -636,7 +636,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349592"
+            "startTime": "2020-05-17T18:52:31.029051"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -647,7 +647,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349598"
+            "startTime": "2020-05-17T18:52:31.029060"
           },
           "deliveryLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -691,7 +691,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349651",
+          "createdDate": "2020-05-17T18:52:31.029111",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -708,7 +708,7 @@
           "recipientPhoneNumber": "947.196.5934x2320",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349655"
+            "startTime": "2020-05-17T18:52:31.029116"
           },
           "pickUpLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -719,7 +719,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.349662"
+            "startTime": "2020-05-17T18:52:31.029122"
           },
           "deliveryLocation": {
             "address": "13123 Shenley St, Sylmar, CA 91342, USA",
@@ -747,7 +747,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349692",
+          "createdDate": "2020-05-17T18:52:31.029148",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -764,7 +764,7 @@
           "recipientPhoneNumber": "489.241.1578x1565",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349697"
+            "startTime": "2020-05-17T18:52:31.029152"
           },
           "pickUpLocation": {
             "address": "1165 1/2 N Kingsley Dr #1190, Los Angeles, CA 90029, USA",
@@ -775,7 +775,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.349704"
+            "startTime": "2020-05-17T18:52:31.029158"
           },
           "deliveryLocation": {
             "address": "2323 Thelma Ave, Los Angeles, CA 90032, USA",
@@ -803,7 +803,7 @@
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349732",
+          "createdDate": "2020-05-17T18:52:31.029183",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -820,7 +820,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.349736"
+            "startTime": "2020-05-17T18:52:31.029188"
           },
           "pickUpLocation": {
             "address": "2393 Silver Ridge Ave, Los Angeles, CA 90039, USA",
@@ -831,7 +831,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.349742"
+            "startTime": "2020-05-17T18:52:31.029194"
           },
           "deliveryLocation": {
             "address": "639 N Westmoreland Ave, Los Angeles, CA 90004, USA",
@@ -859,7 +859,7 @@
               "description": "8 or 9 types, like broccoli, celery and kale."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349772",
+          "createdDate": "2020-05-17T18:52:31.029220",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -876,7 +876,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349777"
+            "startTime": "2020-05-17T18:52:31.029225"
           },
           "pickUpLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -887,7 +887,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349784"
+            "startTime": "2020-05-17T18:52:31.029231"
           },
           "deliveryLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -931,9 +931,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349821",
+          "createdDate": "2020-05-17T18:52:31.029264",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.349845",
+          "fundedDate": "2020-05-17T18:52:31.029300",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -948,7 +948,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349827"
+            "startTime": "2020-05-17T18:52:31.029269"
           },
           "pickUpLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -959,7 +959,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.349834"
+            "startTime": "2020-05-17T18:52:31.029289"
           },
           "deliveryLocation": {
             "address": "3243 Farnsworth Ave, Los Angeles, CA 90032, USA",
@@ -1003,7 +1003,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349885",
+          "createdDate": "2020-05-17T18:52:31.029340",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1020,7 +1020,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.349889"
+            "startTime": "2020-05-17T18:52:31.029344"
           },
           "pickUpLocation": {
             "address": "784 N Alexandria Ave, Los Angeles, CA 90029, USA",
@@ -1031,7 +1031,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349895"
+            "startTime": "2020-05-17T18:52:31.029352"
           },
           "deliveryLocation": {
             "address": "690 Imogen Ave #10, Los Angeles, CA 90026, USA",
@@ -1075,7 +1075,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349927",
+          "createdDate": "2020-05-17T18:52:31.029382",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1092,7 +1092,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349931"
+            "startTime": "2020-05-17T18:52:31.029386"
           },
           "pickUpLocation": {
             "address": "12321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -1103,7 +1103,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349938"
+            "startTime": "2020-05-17T18:52:31.029392"
           },
           "deliveryLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -1147,7 +1147,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.349969",
+          "createdDate": "2020-05-17T18:52:31.029422",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1164,7 +1164,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.349973"
+            "startTime": "2020-05-17T18:52:31.029427"
           },
           "pickUpLocation": {
             "address": "2393 Silver Ridge Ave, Los Angeles, CA 90039, USA",
@@ -1175,7 +1175,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.349980"
+            "startTime": "2020-05-17T18:52:31.029432"
           },
           "deliveryLocation": {
             "address": "639 N Westmoreland Ave, Los Angeles, CA 90004, USA",
@@ -1211,9 +1211,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350010",
+          "createdDate": "2020-05-17T18:52:31.029463",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.350035",
+          "fundedDate": "2020-05-17T18:52:31.029484",
           "readyToStart": false,
           "groupUid": "Daly City 2020/05/05",
           "groupDisplayName": "Daly City 2020/05/05",
@@ -1228,7 +1228,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350015"
+            "startTime": "2020-05-17T18:52:31.029468"
           },
           "pickUpLocation": {
             "address": "12321 De Garmo Ave, Sylmar, CA 91342, USA",
@@ -1239,7 +1239,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350021"
+            "startTime": "2020-05-17T18:52:31.029474"
           },
           "deliveryLocation": {
             "address": "4910 W Adams Blvd #1, Los Angeles, CA 90016, USA",
@@ -1267,7 +1267,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350070",
+          "createdDate": "2020-05-17T18:52:31.029521",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1284,7 +1284,7 @@
           "recipientPhoneNumber": "+1-891-013-9916x1510",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350075"
+            "startTime": "2020-05-17T18:52:31.029526"
           },
           "pickUpLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -1295,7 +1295,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350081"
+            "startTime": "2020-05-17T18:52:31.029531"
           },
           "deliveryLocation": {
             "address": "13321 Tripoli Ave, Sylmar, CA 91342, USA",
@@ -1331,7 +1331,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350108",
+          "createdDate": "2020-05-17T18:52:31.029561",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1348,7 +1348,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.350113"
+            "startTime": "2020-05-17T18:52:31.029566"
           },
           "pickUpLocation": {
             "address": "1165 1/2 N Kingsley Dr #1190, Los Angeles, CA 90029, USA",
@@ -1359,7 +1359,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350118"
+            "startTime": "2020-05-17T18:52:31.029572"
           },
           "deliveryLocation": {
             "address": "4910 W Adams Blvd #1, Los Angeles, CA 90016, USA",
@@ -1403,7 +1403,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350152",
+          "createdDate": "2020-05-17T18:52:31.029604",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1420,7 +1420,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.350157"
+            "startTime": "2020-05-17T18:52:31.029609"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -1431,7 +1431,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350162"
+            "startTime": "2020-05-17T18:52:31.029617"
           },
           "deliveryLocation": {
             "address": "3673 2nd Ave, Los Angeles, CA 90018, USA",
@@ -1475,9 +1475,9 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350196",
+          "createdDate": "2020-05-17T18:52:31.029650",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.350218",
+          "fundedDate": "2020-05-17T18:52:31.029671",
           "readyToStart": true,
           "groupUid": null,
           "groupDisplayName": null,
@@ -1492,7 +1492,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.350201"
+            "startTime": "2020-05-17T18:52:31.029655"
           },
           "pickUpLocation": {
             "address": "Tucker Ave, Los Angeles, CA 91342, USA",
@@ -1503,7 +1503,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.350207"
+            "startTime": "2020-05-17T18:52:31.029661"
           },
           "deliveryLocation": {
             "address": "5545 Via Marisol, Los Angeles, CA 90042, USA",
@@ -1531,7 +1531,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350253",
+          "createdDate": "2020-05-17T18:52:31.029705",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1548,7 +1548,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.350258"
+            "startTime": "2020-05-17T18:52:31.029709"
           },
           "pickUpLocation": {
             "address": "5322 Weaver St, Los Angeles, CA 90042, USA",
@@ -1559,7 +1559,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.350264"
+            "startTime": "2020-05-17T18:52:31.029715"
           },
           "deliveryLocation": {
             "address": "13321 Pala Ave, Sylmar, CA 91342, USA",
@@ -1587,9 +1587,9 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350292",
+          "createdDate": "2020-05-17T18:52:31.029741",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.350313",
+          "fundedDate": "2020-05-17T18:52:31.029762",
           "readyToStart": true,
           "groupUid": "Union Square 2020/05/04",
           "groupDisplayName": "Union Square 2020/05/04",
@@ -1604,7 +1604,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350296"
+            "startTime": "2020-05-17T18:52:31.029746"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -1615,7 +1615,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.350302"
+            "startTime": "2020-05-17T18:52:31.029752"
           },
           "deliveryLocation": {
             "address": "5545 Via Marisol, Los Angeles, CA 90042, USA",
@@ -1643,7 +1643,7 @@
               "description": "A smaller loose leaf box baby arugula, baby spinach, salad mix, Italian parsley, cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350350",
+          "createdDate": "2020-05-17T18:52:31.029796",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1660,7 +1660,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350354"
+            "startTime": "2020-05-17T18:52:31.029801"
           },
           "pickUpLocation": {
             "address": "13932 Hubbard St, Sylmar, CA 91342, USA",
@@ -1671,7 +1671,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350361"
+            "startTime": "2020-05-17T18:52:31.029807"
           },
           "deliveryLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -1715,7 +1715,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350394",
+          "createdDate": "2020-05-17T18:52:31.029842",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1732,7 +1732,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350399"
+            "startTime": "2020-05-17T18:52:31.029846"
           },
           "pickUpLocation": {
             "address": "13123 Harps St, Sylmar, CA 91342, USA",
@@ -1743,7 +1743,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.350404"
+            "startTime": "2020-05-17T18:52:31.029852"
           },
           "deliveryLocation": {
             "address": "743 1/2 N Heliotrope Dr #1010, Los Angeles, CA 90029, USA",
@@ -1787,7 +1787,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350585",
+          "createdDate": "2020-05-17T18:52:31.029886",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1804,7 +1804,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350593"
+            "startTime": "2020-05-17T18:52:31.029891"
           },
           "pickUpLocation": {
             "address": "125 S Everett St #2, Glendale, CA 91205, USA",
@@ -1815,7 +1815,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350600"
+            "startTime": "2020-05-17T18:52:31.029897"
           },
           "deliveryLocation": {
             "address": "891 Yoakum St, Los Angeles, CA 90032, USA",
@@ -1859,7 +1859,7 @@
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350643",
+          "createdDate": "2020-05-17T18:52:31.029927",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -1876,7 +1876,7 @@
           "recipientPhoneNumber": "801.609.7535",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350648"
+            "startTime": "2020-05-17T18:52:31.029931"
           },
           "pickUpLocation": {
             "address": "13321 Tripoli Ave, Sylmar, CA 91342, USA",
@@ -1887,7 +1887,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350653"
+            "startTime": "2020-05-17T18:52:31.029937"
           },
           "deliveryLocation": {
             "address": "743 1/2 N Heliotrope Dr #1010, Los Angeles, CA 90029, USA",
@@ -1923,9 +1923,9 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350684",
+          "createdDate": "2020-05-17T18:52:31.029983",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.350711",
+          "fundedDate": "2020-05-17T18:52:31.030011",
           "readyToStart": true,
           "groupUid": null,
           "groupDisplayName": null,
@@ -1940,7 +1940,7 @@
           "recipientPhoneNumber": "6984564280",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350689"
+            "startTime": "2020-05-17T18:52:31.029990"
           },
           "pickUpLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -1951,7 +1951,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350698"
+            "startTime": "2020-05-17T18:52:31.029998"
           },
           "deliveryLocation": {
             "address": "802 N Normandie Ave, Los Angeles, CA 90029, USA",
@@ -1979,7 +1979,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350747",
+          "createdDate": "2020-05-17T18:52:31.030057",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -1996,7 +1996,7 @@
           "recipientPhoneNumber": "+1-891-013-9916x1510",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350752"
+            "startTime": "2020-05-17T18:52:31.030064"
           },
           "pickUpLocation": {
             "address": "13321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2007,7 +2007,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350758"
+            "startTime": "2020-05-17T18:52:31.030072"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",
@@ -2035,7 +2035,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350783",
+          "createdDate": "2020-05-17T18:52:31.030108",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2052,7 +2052,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350787"
+            "startTime": "2020-05-17T18:52:31.030115"
           },
           "pickUpLocation": {
             "address": "13123 Pala Ave, Sylmar, CA 91342, USA",
@@ -2063,7 +2063,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.350793"
+            "startTime": "2020-05-17T18:52:31.030122"
           },
           "deliveryLocation": {
             "address": "Tucker Ave, Los Angeles, CA 91342, USA",
@@ -2099,7 +2099,7 @@
               "description": "Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350820",
+          "createdDate": "2020-05-17T18:52:31.030159",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -2116,7 +2116,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350824"
+            "startTime": "2020-05-17T18:52:31.030165"
           },
           "pickUpLocation": {
             "address": "13321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2127,7 +2127,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350830"
+            "startTime": "2020-05-17T18:52:31.030173"
           },
           "deliveryLocation": {
             "address": "1813 Potomac Ave, Los Angeles, CA 90016, USA",
@@ -2163,7 +2163,7 @@
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350860",
+          "createdDate": "2020-05-17T18:52:31.030217",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2180,7 +2180,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350864"
+            "startTime": "2020-05-17T18:52:31.030224"
           },
           "pickUpLocation": {
             "address": "912 Yoakum St, Los Angeles, CA 90032, USA",
@@ -2191,7 +2191,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350870"
+            "startTime": "2020-05-17T18:52:31.030231"
           },
           "deliveryLocation": {
             "address": "12321 Gladstone Ave, Sylmar, CA 91342, USA",
@@ -2219,7 +2219,7 @@
               "description": "Loose-leaf box: 1/2 baby arugula, 1/2 baby spinach, 1/2 salad mix, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350894",
+          "createdDate": "2020-05-17T18:52:31.030266",
           "fundedStatus": "fundedbyrecipient",
           "fundedDate": "",
           "readyToStart": true,
@@ -2236,7 +2236,7 @@
           "recipientPhoneNumber": "634-579-2302",
           "pickUpWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350899"
+            "startTime": "2020-05-17T18:52:31.030272"
           },
           "pickUpLocation": {
             "address": "901 S Avenue 60, Los Angeles, CA 90042, USA",
@@ -2247,7 +2247,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.350904"
+            "startTime": "2020-05-17T18:52:31.030280"
           },
           "deliveryLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -2291,7 +2291,7 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350939",
+          "createdDate": "2020-05-17T18:52:31.030322",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2308,7 +2308,7 @@
           "recipientPhoneNumber": "001-008-691-4131",
           "pickUpWindow": {
             "timeWindowType": "whenever possible",
-            "startTime": "2020-05-16T16:37:37.350944"
+            "startTime": "2020-05-17T18:52:31.030328"
           },
           "pickUpLocation": {
             "address": "13321 Pala Ave, Sylmar, CA 91342, USA",
@@ -2319,7 +2319,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350950"
+            "startTime": "2020-05-17T18:52:31.030336"
           },
           "deliveryLocation": {
             "address": "14123 Clymer St, San Fernando, CA 91340, USA",
@@ -2363,7 +2363,7 @@
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.350985",
+          "createdDate": "2020-05-17T18:52:31.030376",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2380,7 +2380,7 @@
           "recipientPhoneNumber": "947.196.5934x2320",
           "pickUpWindow": {
             "timeWindowType": "as soon as possible",
-            "startTime": "2020-05-16T16:37:37.350990"
+            "startTime": "2020-05-17T18:52:31.030382"
           },
           "pickUpLocation": {
             "address": "13123 Fellows Ave, Sylmar, CA 91342, USA",
@@ -2391,7 +2391,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.350996"
+            "startTime": "2020-05-17T18:52:31.030389"
           },
           "deliveryLocation": {
             "address": "2832 S Mansfield Ave, Los Angeles, CA 90016, USA",
@@ -2427,7 +2427,7 @@
               "description": "Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.351026",
+          "createdDate": "2020-05-17T18:52:31.030425",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2444,7 +2444,7 @@
           "recipientPhoneNumber": "+1-018-684-8339x69477",
           "pickUpWindow": {
             "timeWindowType": "afternoon",
-            "startTime": "2020-05-16T16:37:37.351031"
+            "startTime": "2020-05-17T18:52:31.030432"
           },
           "pickUpLocation": {
             "address": "14321 Rinaldi St, San Fernando, CA 91340, USA",
@@ -2455,7 +2455,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.351037"
+            "startTime": "2020-05-17T18:52:31.030439"
           },
           "deliveryLocation": {
             "address": "784 N Alexandria Ave, Los Angeles, CA 90029, USA",
@@ -2491,7 +2491,7 @@
               "description": "Frisee and Head Lettuce box - one of every head of lettuce, 1/2 lb bag baby spinach, 1/4lb Italian parsley, 1/4lb cilantro"
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.351067",
+          "createdDate": "2020-05-17T18:52:31.030475",
           "fundedStatus": "notfunded",
           "fundedDate": "",
           "readyToStart": false,
@@ -2508,7 +2508,7 @@
           "recipientPhoneNumber": "871-158-7148",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.351071"
+            "startTime": "2020-05-17T18:52:31.030480"
           },
           "pickUpLocation": {
             "address": "690 Imogen Ave #10, Los Angeles, CA 90026, USA",
@@ -2519,7 +2519,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "morning",
-            "startTime": "2020-05-16T16:37:37.351077"
+            "startTime": "2020-05-17T18:52:31.030491"
           },
           "deliveryLocation": {
             "address": "1014 N Mariposa Ave #110, Los Angeles, CA 90029, USA",
@@ -2547,9 +2547,9 @@
               "description": "8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
             }
           ],
-          "createdDate": "2020-05-16T16:37:37.351102",
+          "createdDate": "2020-05-17T18:52:31.030529",
           "fundedStatus": "fundedbyrecipient",
-          "fundedDate": "2020-05-16T16:37:37.351123",
+          "fundedDate": "2020-05-17T18:52:31.030556",
           "readyToStart": false,
           "groupUid": null,
           "groupDisplayName": null,
@@ -2564,7 +2564,7 @@
           "recipientPhoneNumber": "953-304-1352",
           "pickUpWindow": {
             "timeWindowType": "wholeday",
-            "startTime": "2020-05-16T16:37:37.351106"
+            "startTime": "2020-05-17T18:52:31.030535"
           },
           "pickUpLocation": {
             "address": "CA-2, California, USA",
@@ -2575,7 +2575,7 @@
           "pickUpNotes": "",
           "deliveryWindow": {
             "timeWindowType": "exact",
-            "startTime": "2020-05-16T16:37:37.351112"
+            "startTime": "2020-05-17T18:52:31.030543"
           },
           "deliveryLocation": {
             "address": "5123 W 20th St, Los Angeles, CA 90016, USA",

--- a/scheme/data.py
+++ b/scheme/data.py
@@ -155,6 +155,8 @@ class Organization:
             "lat": 34.1483989,
             "lng": -118.3961877
         },
+        # i dont know why this is necessary but it works!
+        self.location = self.location[0]
         self.localTimeZone = ''
         self.phoneNumber = f.phone_number()
         self.EINNumber = '12-3456789'
@@ -330,7 +332,7 @@ if __name__ == "__main__":
 
     db = Database(resources)
     organization = db.create_organization(resources)
-
+    
     for i in range(40):
         organization.create_random_mission(db.any_user())
 

--- a/scheme/resources.csv
+++ b/scheme/resources.csv
@@ -5,4 +5,4 @@ uid,displayName,cost,availableToOrder,type,description
 "4","Produce Box #3 (large)","8",true,"foodbox","8 or 9 types, like broccoli, celery and kale."
 "5","Produce Box #3 b (small)",14,true,"foodbox","8 or 9 types of produce, like broccoli, celery and kale, but smaller quantities than the large box."
 "6","Produce Box #4: Fruit Box",30,true,"foodbox","Oranges, Mandarins, Grapefruits, Lemons, and Peaches"
-"7","Produce Box # 5: Donation Box",25, true,"donationbox","Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."
+"7","Donate a box",25, true,"donationbox","Enter the number of donation produce boxes you want to donate, for none leave blank or put a 0. Donations are 100% tax-deductible."

--- a/src/app/component/MissionComponent/DetailsText.jsx
+++ b/src/app/component/MissionComponent/DetailsText.jsx
@@ -17,8 +17,6 @@ const ResourceDetails = ({ details }) => {
 const DetailsText = ({ mission }) => {
   const { details, type } = mission;
 
-  let Details = null;
-
   if (type === "resource") {
     return <ResourceDetails details={details} />;
   }

--- a/src/app/dashboard/Missions/DetailsView.jsx
+++ b/src/app/dashboard/Missions/DetailsView.jsx
@@ -160,7 +160,7 @@ const FoodBoxDetailsRow = ({ classes, details }) => {
 const MissionDetailsRow = ({ classes, mission }) => {
   let type = mission?.type;
   let details = mission?.details;
-  if (type === "foodbox") {
+  if (type === "resource") {
     return <FoodBoxDetailsRow details={details} classes={classes} />;
   }
   return null;

--- a/src/app/dashboard/Missions/DetailsView.jsx
+++ b/src/app/dashboard/Missions/DetailsView.jsx
@@ -159,7 +159,7 @@ const FoodBoxDetailsRow = ({ classes, details }) => {
 
 const MissionDetailsRow = ({ classes, mission }) => {
   let type = mission?.type;
-  let details = mission?.missionDetails;
+  let details = mission?.details;
   if (type === "foodbox") {
     return <FoodBoxDetailsRow details={details} classes={classes} />;
   }

--- a/src/app/dashboard/Missions/MapView.jsx
+++ b/src/app/dashboard/Missions/MapView.jsx
@@ -125,7 +125,6 @@ const Overview = ({ currentMission, missions, org, setSelectedMission, volunteer
 };
 
 function MissionMarker({ currentUid, groups, mission, setSelectedMission, volunteers }) {
-  console.log(mission);
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
   let html = `<div class='${clsx(
@@ -142,7 +141,6 @@ function MissionMarker({ currentUid, groups, mission, setSelectedMission, volunt
     );
     html += GroupIconHtml;
   }
-  console.log(mission);
 
   const FoodboxIconHtml = renderToString(<FoodBoxIcon className={classes.innerFoodBoxMarker} />);
   html += FoodboxIconHtml;

--- a/src/app/dashboard/Missions/MapView.jsx
+++ b/src/app/dashboard/Missions/MapView.jsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
   innerFoodBoxMarker: {
     width: "15px !important",
     height: "15px !important",
-    top: "14px",
+    transform: "translate(8px, 13px)",
     position: "relative",
   },
   markerPin: {
@@ -76,9 +76,8 @@ const useStyles = makeStyles((theme) => ({
 
 const Overview = ({ currentMission, missions, org, setSelectedMission, volunteers }) => {
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] = React.useState(null);
 
-  const position = { lat: org.location.lat, lng: org.location.lng };
+  const position = { lat: org.location?.lat, lng: org.location?.lng };
 
   const [viewport, setViewport] = useState({
     center: position,
@@ -86,7 +85,7 @@ const Overview = ({ currentMission, missions, org, setSelectedMission, volunteer
   });
 
   let filtered = missions?.filter((mission) => {
-    return mission.deliveryLocation && mission.deliveryLocation.lat && mission.deliveryLocation.lng;
+    return mission?.deliveryLocation?.lat && mission?.deliveryLocation?.lng;
   });
 
   const { groups, singleMissions } = Mission.getAllGroups(filtered);
@@ -103,77 +102,6 @@ const Overview = ({ currentMission, missions, org, setSelectedMission, volunteer
     // eslint-disable-next-line
   }, [currentMission]);
 
-  const getMarker = (mission) => {
-    let html = `<div class='${clsx(
-      classes.markerPin,
-      currentMission && currentMission.uid === mission.uid && classes.currentMarker
-    )}'></div>`;
-    let color = "black";
-    if (mission.groupDisplayName) {
-      color = _.randomColor(mission.groupDisplayName);
-      const GroupIconHtml = renderToString(
-        <GroupWorkIcon className={classes.customGroupIcon} style={{ color: color }} />
-      );
-      html += GroupIconHtml;
-    }
-    let SpecificDetails = null;
-    if (mission.type === "foodbox") {
-      SpecificDetails = (
-        <>
-          <b>Food Box</b>
-          {_.get(mission.missionDetails, "needs")?.map((box, index) => {
-            return (
-              <div key={index}>
-                {_.get(box, "quantity")} x {_.get(box, "name")}
-              </div>
-            );
-          })}
-        </>
-      );
-
-      const FoodboxIconHtml = renderToString(
-        <FoodBoxIcon className={classes.innerFoodBoxMarker} />
-      );
-      html += FoodboxIconHtml;
-    }
-
-    const CustomIcon = new DivIcon({
-      className: clsx(classes.customDivIcon),
-      html: html,
-      iconSize: [30, 42],
-      iconAnchor: [15, 42], // half of width + height
-    });
-
-    return (
-      <Marker
-        icon={CustomIcon}
-        key={mission.uid}
-        position={mission.deliveryLocation}
-        onClick={(event) => {
-          setAnchorEl(event.target.getElement());
-          setSelectedMission(mission.uid);
-        }}
-      >
-        <Popup className={classes.popup} autoClose={true}>
-          <Grid container>
-            <Grid container item xs>
-              {mission.groupDisplayName && mission.groupDisplayName}
-              {SpecificDetails}
-            </Grid>
-            <Grid item>
-              <MissionItemMenu
-                groups={groups}
-                mission={mission}
-                volunteers={volunteers}
-                boxRef={{ current: anchorEl }}
-              />
-            </Grid>
-          </Grid>
-        </Popup>
-      </Marker>
-    );
-  };
-
   return (
     <Box height="100%">
       <Map
@@ -182,12 +110,84 @@ const Overview = ({ currentMission, missions, org, setSelectedMission, volunteer
         className={`${classes.map} data-test-leaftleft-map`}
       >
         <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-        {filtered?.map((mission) => {
-          return getMarker(mission);
-        })}
+        {filtered?.map((mission) => (
+          <MissionMarker
+            mission={mission}
+            currentUid={currentMission?.uid}
+            setSelectedMission={setSelectedMission}
+            groups={groups}
+            volunteers={volunteers}
+          />
+        ))}
       </Map>
     </Box>
   );
 };
+
+function MissionMarker({ currentUid, groups, mission, setSelectedMission, volunteers }) {
+  console.log(mission);
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  let html = `<div class='${clsx(
+    classes.markerPin,
+    currentUid === mission.uid && classes.currentMarker
+  )}'></div>`;
+
+  let color = "black";
+
+  if (mission.groupDisplayName) {
+    color = _.randomColor(mission.groupDisplayName);
+    const GroupIconHtml = renderToString(
+      <GroupWorkIcon className={classes.customGroupIcon} style={{ color: color }} />
+    );
+    html += GroupIconHtml;
+  }
+  console.log(mission);
+
+  const FoodboxIconHtml = renderToString(<FoodBoxIcon className={classes.innerFoodBoxMarker} />);
+  html += FoodboxIconHtml;
+
+  const CustomIcon = new DivIcon({
+    className: clsx(classes.customDivIcon),
+    html: html,
+    iconSize: [30, 42],
+    iconAnchor: [15, 42], // half of width + height
+  });
+
+  return (
+    <Marker
+      icon={CustomIcon}
+      key={mission.uid}
+      position={mission.deliveryLocation}
+      onClick={(event) => {
+        setAnchorEl(event.target.getElement());
+        setSelectedMission(mission.uid);
+      }}
+    >
+      <Popup className={classes.popup} autoClose={true}>
+        <Grid container>
+          <Grid container item xs>
+            {mission.groupDisplayName}
+            {mission.details?.map((box, index) => {
+              return (
+                <div key={index}>
+                  {box.quantity} x {box.displayName}
+                </div>
+              );
+            })}
+          </Grid>
+          <Grid item>
+            <MissionItemMenu
+              groups={groups}
+              mission={mission}
+              volunteers={volunteers}
+              boxRef={{ current: anchorEl }}
+            />
+          </Grid>
+        </Grid>
+      </Popup>
+    </Marker>
+  );
+}
 
 export default Overview;

--- a/src/app/model/Mission.ts
+++ b/src/app/model/Mission.ts
@@ -35,7 +35,7 @@ const defaultMissionData: MissionInterface = {
   type: MissionType.errand,
   status: MissionStatus.unassigned,
   createdDate: "",
-  missionDetails: null,
+  details: null,
   fundedStatus: MissionFundedStatus.notfunded,
   fundedDate: "",
   readyToStart: false,

--- a/src/app/model/schema.ts
+++ b/src/app/model/schema.ts
@@ -179,7 +179,7 @@ export interface MissionInterface {
   status: MissionStatus;
 
   type: MissionType;
-  missionDetails: Array<ResourceMissionDetails> | null;
+  details: Array<ResourceMissionDetails> | null;
 
   createdDate: string; // TODO should be a date?
 

--- a/src/app/page/Request/foodbox/ConfirmStep.jsx
+++ b/src/app/page/Request/foodbox/ConfirmStep.jsx
@@ -69,7 +69,7 @@ function ConfirmStep({ dispatch, state }) {
       deliveryLocation: details.location,
       deliveryNotes: details.instructions,
       deliveryType: details.curbsidePickup ? "curbside" : "delivery",
-      missionDetails: Object.keys(cart).map((key) => ({
+      details: Object.keys(cart).map((key) => ({
         resourceUid: cart[key].resource.uid,
         quantity: cart[key].quantity,
         displayName: cart[key].resource.displayName,


### PR DESCRIPTION
fixes #550 
Plus fixes an issue with the details object on missions getting renamed

data properly shows on markers now
![image](https://user-images.githubusercontent.com/20975817/82133346-2f81c880-97b9-11ea-9887-5bdabb1e1c27.png)
