### PR TITLE
Fix title display for mission cards

### DIFF
--- a/src/app/dashboard/Missions/DetailsView.jsx
+++ b/src/app/dashboard/Missions/DetailsView.jsx
@@ -107,11 +107,13 @@ const MissionTypeRow = ({ classes, mission }) => {
   let missionTypeText;
   switch (mission?.type) {
     case Mission.Type.resource:
-      missionTypeText = "Resource Delivery";
+      missionTypeText = "Foodbox";
       break;
-    // at some point we need to add other mission types
+    case Mission.Type.errand:
+      missionTypeText = "General Errand";
+      break;
     default:
-      missionTypeText = "Mission";
+      missionTypeText = "Mission Name";
   }
   return (
     <Box marginTop="32px">

--- a/src/app/dashboard/Missions/DetailsView.jsx
+++ b/src/app/dashboard/Missions/DetailsView.jsx
@@ -102,6 +102,24 @@ const MissionImage = ({ classes, mission }) => {
     </Container>
   );
 };
+
+const MissionTypeRow = ({ classes, mission }) => {
+  let missionTypeText;
+  switch (mission?.type) {
+    case Mission.Type.resource:
+      missionTypeText = "Resource Delivery";
+      break;
+    // at some point we need to add other mission types
+    default:
+      missionTypeText = "Mission";
+  }
+  return (
+    <Box marginTop="32px">
+      <H3>{missionTypeText}</H3>
+    </Box>
+  );
+};
+
 const VolunteerRow = ({ mission }) => {
   const { tentativeVolunteerDisplayName, volunteerDisplayName } = mission;
   let assigned = "";
@@ -175,7 +193,6 @@ const MissionDetailsCard = ({ mission, toListView }) => {
   const recipientPhoneNumber = _.get(mission, "recipientPhoneNumber");
 
   const props = { classes: classes, mission: mission };
-
   return (
     <Box height="100%" width="100%">
       <Paper className={classes.root} elevation={0}>
@@ -185,10 +202,8 @@ const MissionDetailsCard = ({ mission, toListView }) => {
         {isLoaded(mission) && !isEmpty(mission) && (
           <Box>
             <MissionImage {...props} />
-            <Box marginTop="32px">
-              <H3>{mission?.type}</H3>
-            </Box>
 
+            <MissionTypeRow {...props} />
             <VolunteerRow {...props} />
             <MissionFundedStatusRow {...props} />
             <MissionDetailsRow {...props} />

--- a/src/app/model/Mission.ts
+++ b/src/app/model/Mission.ts
@@ -198,6 +198,7 @@ const getAllGroups = (missions: MissionInterface[]) => {
 class Mission extends BaseModel {
   collectionName = "missions";
   Status = MissionStatus;
+  Type = MissionType;
   FundedStatus = MissionFundedStatus;
   TimeWindowType = TimeWindowType;
 


### PR DESCRIPTION
Fixes #555 by replacing the MissionTypeRow render as rendering mission?.type results in rendering plain 'resource' as the mission title. It also updates the Mission model to export the types for comparison.

This also will close the minor QA holding off #449 