### PR TITLE
Fix text overlapping for grid elements in missions

### DIFF
--- a/src/app/component/MissionComponent/MissionCard.jsx
+++ b/src/app/component/MissionComponent/MissionCard.jsx
@@ -54,6 +54,11 @@ const createCustomTheme = (theme) =>
           paddingBottom: 0,
         },
       },
+      MuiGrid: {
+        "grid-xs-true": {
+          flexBasis: "auto",
+        },
+      },
     },
   });
 const styles = (theme) => ({


### PR DESCRIPTION
fixes #507 

<img width="425" alt="Screen Shot 2020-05-17 at 21 17 04" src="https://user-images.githubusercontent.com/41974547/82166524-b355b680-9886-11ea-8412-78a32517b105.png">

The grid-xs-true class's `flex-basis: 0` was causing the overlap in safari. I overrode this and set it to the default value of auto. I tested this in chrome and firefox and it looked good in both.