### PR TITLE
Add build step to dev env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Here are a few geting started steps to help get set up for local development.
 7. Start your local development server with
 
    ```sh
+   npm run build
    npm run dev
    ```
 _NOTE_: On local development environment, you are always an Organizer.


### PR DESCRIPTION
I needed to run `npm run build` before I was able to start the dev server; this may or may not be necessary for everyone but I don't think it hurts.