### PR TITLE
Fix volunteer profile signup not submitting

### DIFF
--- a/src/app/model/User.ts
+++ b/src/app/model/User.ts
@@ -18,7 +18,7 @@ const defaultUserData: UserInterface = {
   phoneNumber: "",
   email: "",
   location: defaultLocation,
-  organizationUid: 0,
+  organizationUid: "",
   isVolunteer: false,
   isOrganizer: false,
   volunteerDetails: {

--- a/src/app/model/schema.ts
+++ b/src/app/model/schema.ts
@@ -87,7 +87,7 @@ export class UserInterface {
   /* user location, we use this to show user on a map */
   location?: Location;
   /* the organization that user belong to*/
-  organizationUid!: number;
+  organizationUid!: string;
   /* if user is a volunteer */
   isVolunteer!: boolean;
   /* if user is an organizer */

--- a/src/app/page/Signup/ConnectSocialMedia/ConnectSocialMedia.jsx
+++ b/src/app/page/Signup/ConnectSocialMedia/ConnectSocialMedia.jsx
@@ -57,8 +57,8 @@ const ConnectSocialMedia = ({ onConnectSuccess, onSkip }) => {
 };
 
 ConnectSocialMedia.propTypes = {
-  handleButtonClick: PropTypes.func.isRequired,
-  signInSuccess: PropTypes.func.isRequired,
+  onConnectSuccess: PropTypes.func.isRequired,
+  onSkip: PropTypes.func.isRequired,
 };
 
 export default ConnectSocialMedia;

--- a/src/app/page/Signup/PhoneAuth/PhoneAuth.jsx
+++ b/src/app/page/Signup/PhoneAuth/PhoneAuth.jsx
@@ -17,7 +17,7 @@ const PhoneAuth = ({ onSignupSuccess }) => {
     callbacks: {
       signInSuccessWithAuthResult: function (authResult) {
         var user = authResult.user;
-        /** 
+        /**
          * TODO we are suppose to do with new user, do not rember what it was
         var credential = authResult.credential;
         var isNewUser = authResult.additionalUserInfo.isNewUser;
@@ -37,7 +37,7 @@ const PhoneAuth = ({ onSignupSuccess }) => {
 };
 
 PhoneAuth.propTypes = {
-  signInSuccess: PropTypes.func.isRequired,
+  onSignupSuccess: PropTypes.func.isRequired,
 };
 
 export default PhoneAuth;

--- a/src/app/page/Signup/PhoneAuth/PhoneAuth.jsx
+++ b/src/app/page/Signup/PhoneAuth/PhoneAuth.jsx
@@ -17,6 +17,7 @@ const PhoneAuth = ({ onSignupSuccess }) => {
     callbacks: {
       signInSuccessWithAuthResult: function (authResult) {
         var user = authResult.user;
+        console.log({ user });
         /** 
          * TODO we are suppose to do with new user, do not rember what it was
         var credential = authResult.credential;
@@ -37,7 +38,7 @@ const PhoneAuth = ({ onSignupSuccess }) => {
 };
 
 PhoneAuth.propTypes = {
-  signInSuccess: PropTypes.func.isRequired,
+  onSignupSuccess: PropTypes.func.isRequired,
 };
 
 export default PhoneAuth;

--- a/src/app/page/Signup/SignupSuccess/SignupSuccess.jsx
+++ b/src/app/page/Signup/SignupSuccess/SignupSuccess.jsx
@@ -40,7 +40,7 @@ function SignupSuccess({ handleButtonClick }) {
 }
 
 SignupSuccess.propTypes = {
-  handleButtonClick: PropTypes.func,
+  handleButtonClick: PropTypes.func.isRequired,
 };
 
 export default SignupSuccess;


### PR DESCRIPTION
Fixes #472 

To test you can comment out line 45 of RoutePermissions.ts and use the 2223334444 phone number. (This route permissions blocks existing users from signing up again) or just use your own that you haven't used before. If you run `npm run start` you can see the values change in firebase.

I changed the organizationUid to a string to match the uid type in firebase.

In ConnectSocialMedia, PhoneAuth, and SignupSuccess, the prop types no longer matched what was being used, so I updated them (fixed some warnings in my IDE).

The loading state was not being used in SignupScene so I removed it.

I updated the handleSuccess functions in SignupScene to pass the data to updateUser. This prevents the user from updating before the value state finished updating. After the user is successfully updated, then the state is updated along with the page.

I passed the setActiveState in as a callback to updateUser so it could update it after finishing updating the user.

`updateUser()` didn't previously update the user. Now it does.

Lastly I moved the logic for getting the address into a separate function to improve readability. (2 sets of try catches seemed extra).
