### PR TITLE
 Attempt to force index.html to always check for more recent version

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,7 @@
       "source": "/",
       "headers": [ {
         "key": "Cache-Control",
-        "value": "max-age=300"
+        "value": "no-cache"
       } ]
     } ]
   },


### PR DESCRIPTION
Attempt to fix #419 

For a brief moment of time this explanation of cache headings made sense
https://csswizardry.com/2019/03/cache-control-for-civilians/

The intention here is that **only** the root page / (aka index.html)
has the cache-control:no-cache header set.. and that should apparently
result in browsers always checking for that one file (though
if its up to date they can still use cache even though, well anyway
read the article)

As to whether this actually works.. we shall find out!