### PR TITLE
Add og meta tags for social sharing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,20 +9,20 @@
 
     <!-- Twitter Card data -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="Feed Folks">
+    <meta name="twitter:title" content="Studio City - Feed Folks">
     <meta name="twitter:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
     <meta name="twitter:image:src" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395">
 
     <!-- Open Graph data -->
-    <meta property="og:title" content="Feed Folks" />
+    <meta property="og:title" content="Studio City - Feed Folks" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mutualaid-757f6.web.app" />
     <meta property="og:image" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395" />
     <meta property="og:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need." />
-    <meta property="og:site_name" content="Feed Folks" />
+    <meta property="og:site_name" content="Studio City - Feed Folks" />
 
     <!-- Schema.org markup for Google+ -->
-    <meta itemprop="name" content="Feed Folks">
+    <meta itemprop="name" content="Studio City - Feed Folks">
     <meta itemprop="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
     <meta itemprop="image" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395">
 
@@ -52,7 +52,7 @@
       crossorigin=""
     />
 
-    <title>mutualaid.world</title>
+    <title>Studio City - Feed Folks</title>
   </head>
   <body>
     <!-- The core Firebase JS SDK is always required and must be listed first -->

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,12 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
+    <meta name="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
+    <meta property="og:title" content="Feed Folks" />
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://mutualaid-757f6.web.app" />
+    <meta property="og:image" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395" />
+    <meta property="og:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need."/>
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/index.html
+++ b/public/index.html
@@ -5,12 +5,27 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
+    <meta name="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need." />
+
+    <!-- Twitter Card data -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Feed Folks">
+    <meta name="twitter:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
+    <meta name="twitter:image:src" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395">
+
+    <!-- Open Graph data -->
     <meta property="og:title" content="Feed Folks" />
-    <meta property="og:type" content="website"/>
+    <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mutualaid-757f6.web.app" />
     <meta property="og:image" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395" />
-    <meta property="og:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need."/>
+    <meta property="og:description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need." />
+    <meta property="og:site_name" content="Feed Folks" />
+
+    <!-- Schema.org markup for Google+ -->
+    <meta itemprop="name" content="Feed Folks">
+    <meta itemprop="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need.">
+    <meta itemprop="image" content="https://firebasestorage.googleapis.com/v0/b/mutualaid-757f6.appspot.com/o/images%2Ffeedfolks__logo.png?alt=media&token=6b1e803d-9b19-4847-a849-4b4dbdde2395">
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
resolves #596 
<img width="620" alt="Screen Shot 2020-05-20 at 20 43 05" src="https://user-images.githubusercontent.com/41974547/82511160-8d285480-9ada-11ea-82ac-80e8249f1db1.png">
This adds og tags using the organization details. (the local-org.firebaseapp.com won't show up when this is live, I just used that to test the tags on localhost)