### PR TITLE
Replace phone number text field with MuiPhoneNumber component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17391,6 +17391,18 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
       "dev": true
     },
+    "material-ui-phone-number": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/material-ui-phone-number/-/material-ui-phone-number-2.2.6.tgz",
+      "integrity": "sha512-eLGDK9wgvdj2oj+jgmctNtDFznbY7evnuX5hA5OLs5MU5rtE1N4Qs/drRJm3vFct6KOwEwYfaO6XQ+zFUKiI7Q==",
+      "requires": {
+        "clsx": "^1.0.4",
+        "lodash": "^4.17.14",
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "leaflet": "^1.6.0",
     "leaflet-routing-machine": "^3.2.12",
     "lodash": "^4.17.15",
+    "material-ui-phone-number": "^2.2.6",
     "path": "^0.12.7",
     "querystring-browser": "^1.0.4",
     "react": "^16.13.1",

--- a/src/app/layout/Page/Page.jsx
+++ b/src/app/layout/Page/Page.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
  * @param {number} maxWidth - The maximum width of the page.
  * @param {object} rest - Rest of the properties passed to the page..
  */
-const Page = ({ appbar, children, maxWidth, title }) => {
+const Page = ({ appbar, children, maxWidth, title, titleAlign = "left" }) => {
   const classes = useStyles();
   return (
     <Container maxWidth={maxWidth ? maxWidth : "sm"} className={classes.root}>
@@ -38,7 +38,11 @@ const Page = ({ appbar, children, maxWidth, title }) => {
           <Appbar>{appbar}</Appbar>
         </Grid>
         <Grid container item role="main" direction="column">
-          {title && <H1 className={classes.title}>{title}</H1>}
+          {title && (
+            <H1 align={titleAlign} className={classes.title}>
+              {title}
+            </H1>
+          )}
           {children}
         </Grid>
       </Grid>
@@ -47,6 +51,10 @@ const Page = ({ appbar, children, maxWidth, title }) => {
 };
 
 Page.propTypes = {
+  appbar: PropTypes.element,
+  maxWidth: PropTypes.string,
+  title: PropTypes.string,
+  titleAlign: PropTypes.string,
   children: PropTypes.node,
 };
 

--- a/src/app/page/UserProfile/LinkPhoneAccount.jsx
+++ b/src/app/page/UserProfile/LinkPhoneAccount.jsx
@@ -1,10 +1,14 @@
-import { Grid, TextField } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React, { useState } from "react";
 
 import { Button, H5 } from "../../component";
 import SuccessSnackbar from "../../component/Snackbars/SuccessSnackbar";
 import { Card } from "../../layout";
+import { Body2 } from "../../component/Typography";
+import MuiPhoneNumber from "material-ui-phone-number";
+
+const MIN_PHONE_NUMBER_LENGTH = 8;
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -63,11 +67,9 @@ function LinkPhoneAccount({ auth, data, errorHandler, firebase }) {
         successCallback();
       }
     } catch (error) {
-      if (error.code === "auth/argument-error" && error.message.includes("verificationCode")) {
-        setPhoneNumber(currentUserPhoneNumber);
-        return;
-      }
+      setPhoneNumber(currentUserPhoneNumber);
       errorHandler(error);
+      return;
     }
   }
 
@@ -81,12 +83,13 @@ function LinkPhoneAccount({ auth, data, errorHandler, firebase }) {
         <Grid container>
           <Grid item xs={6}>
             <Grid item container>
-              <TextField
-                id="phone-number"
+              <MuiPhoneNumber
+                defaultCountry={"us"}
+                disableAreaCodes={true}
                 value={phoneNumber}
-                helperText="+1 7777777777"
-                onChange={(e) => setPhoneNumber(e.target.value)}
+                onChange={(value) => setPhoneNumber(value)}
               />
+              <Body2>{!currentUserPhoneNumber && "No phone number defined yet"}</Body2>
             </Grid>
           </Grid>
 
@@ -94,10 +97,11 @@ function LinkPhoneAccount({ auth, data, errorHandler, firebase }) {
             id="phone-number-link"
             onClick={onPhoneClick}
             color="secondary"
+            disabled={phoneNumber.length < MIN_PHONE_NUMBER_LENGTH ? true : false}
             variant="contained"
             className={classes.button}
           >
-            {data ? "Change" : "Connect"}
+            {currentUserPhoneNumber ? "Change" : "Connect"}
           </Button>
         </Grid>
       </Grid>

--- a/src/app/page/UserProfile/ProfileImage.jsx
+++ b/src/app/page/UserProfile/ProfileImage.jsx
@@ -70,7 +70,7 @@ const ProfileImage = ({ classes, profile, setProfile }) => {
   ) : (
     <Grid item>
       <Avatar className={classes.profileImage} src={profilePhoto} alt={displayName} />
-      <Link style={{ textDecoration: "none" }} onClick={setEdit}>
+      <Link to="/#" style={{ textDecoration: "none" }} onClick={setEdit}>
         <H4 align="center">Change Picture</H4>
       </Link>
     </Grid>

--- a/src/app/page/UserProfile/UserProfile.js
+++ b/src/app/page/UserProfile/UserProfile.js
@@ -14,6 +14,7 @@ import LinkGoogleAccount from "./LinkGoogleAccount";
 import LinkPhoneAccount from "./LinkPhoneAccount";
 import UserOverview from "./UserOverview";
 import { SnackbarContext } from "../../component/Snackbars/Context";
+import ErrorBoundary from "../../component/ErrorBoundary";
 
 const useStyles = makeStyles((theme) => ({
   spacing: {
@@ -139,10 +140,17 @@ const UserProfile = () => {
         message:
           "We do not support linking with an already existing account. You can sign in to the other account if needed.",
         type: "error",
+        autoHideDuration: null,
+      });
+      return;
+    } else {
+      snackbarContext.show({
+        message: error.message,
+        type: "error",
+        autoHideDuration: null,
       });
       return;
     }
-    throw error;
   }
   /*===END Linking Control===*/
 
@@ -150,33 +158,35 @@ const UserProfile = () => {
   // not used yet
   //<UserStatus status={status} setStatus={setStatus} />
   return (
-    <Page template="white" title="Profile" spacing={3} isLoading={isLoading}>
+    <Page template="white" title="Profile" titleAlign="center" spacing={3} isLoading={isLoading}>
       <UserOverview profile={profile} view={view} setView={setView} setProfile={setProfile} />
-      <Grid item className={classes.fullWidth}>
-        <ProfileControlButtons
-          isEdit={isEdit}
-          saveAction={saveProfileAction}
-          cancelAction={cancelProfileAction}
-          editAction={editProfileAction}
-        />
-      </Grid>
-      <Card>
-        <Grid container className={classes.linkedAccountContainer} spacing={3} direction="column">
-          <LinkPhoneAccount
-            firebase={firebase}
-            data={phoneProviderData}
-            auth={auth}
-            errorHandler={errorHandler}
-            captchaVerifier={captchaVerifier}
-          />
-          <LinkGoogleAccount
-            data={googleProviderData}
-            provider={googleProvider}
-            auth={auth}
-            errorHandler={errorHandler}
+      <ErrorBoundary>
+        <Grid item className={classes.fullWidth}>
+          <ProfileControlButtons
+            isEdit={isEdit}
+            saveAction={saveProfileAction}
+            cancelAction={cancelProfileAction}
+            editAction={editProfileAction}
           />
         </Grid>
-      </Card>
+        <Card>
+          <Grid container className={classes.linkedAccountContainer} spacing={3} direction="column">
+            <LinkPhoneAccount
+              firebase={firebase}
+              data={phoneProviderData}
+              auth={auth}
+              errorHandler={errorHandler}
+              captchaVerifier={captchaVerifier}
+            />
+            <LinkGoogleAccount
+              data={googleProviderData}
+              provider={googleProvider}
+              auth={auth}
+              errorHandler={errorHandler}
+            />
+          </Grid>
+        </Card>
+      </ErrorBoundary>
     </Page>
   );
 };


### PR DESCRIPTION
I replaced text field of phone number with the library of `material-ui-phone-number`. I changed to handle errors when they occurred while adding or changing a phone number. 

Close #414 and #351 

<img width="393" alt="Screenshot 2020-05-22 at 18 56 00" src="https://user-images.githubusercontent.com/1914165/82696010-1916b980-9c5e-11ea-8824-a37d2bbf18d2.png">
