### PR TITLE
Add correct route to favicon and fix chrome manifest warning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/icons/favicon.ico"/>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="We're a grassroots team in Studio City, CA getting fresh farm produce to our neighbors in need." />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "/icons/favicon.ico",
-      "sizes": "64x64 48x48 32x32 24x24 16x16",
+      "sizes": "48x48",
       "type": "image/x-icon"
     },
     {


### PR DESCRIPTION
This pull request will update the site to display the correct favicon.

The favicon wasn't correctly linked in the index.html.
When going to the Application tab of the chrome debugger -> Manifest, it threw a warning about the sizes not being in the correct `HeightxWidth` format. I switched it to 16x16 and then it said that it didn't match the 48x48 file, so I changed it to 48x48 and it stopped giving warnings. 
This might help fix #272 but from what I've read this is a chrome bug, while testing it stopped sending a request to favicon for pages I had already visited.