### PR TITLE
Change cursor to default so useless button doesn't show clickability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,6 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  display: flex;
   align-items: center;
 }
 
@@ -57,4 +56,11 @@
   font-weight: 600;
   font-size: 14px;
   line-height: 24px;
+}
+
+/* Overrides Algolia style.
+ * Button asks for location but doesn't do anything with info, so we don't need to show click ability
+ */
+.ap-input-icon.ap-icon-pin {
+  cursor: default;
 }


### PR DESCRIPTION
Resolves #300 
There is a button in Algolia places that shows you can click it. All it does is ask for the user's location but doesn't do anything with this info. For this reason we can hide that it's clickable so it doesn't confuse users into thinking they can fill their location with that button.
(I also removed a `display:flex` in app because if you look above it, it's already delared)