### PR TITLE
Allow volunteers to accept groups of missions

### DIFF
--- a/src/app/component/MissionComponent/MissionCard.jsx
+++ b/src/app/component/MissionComponent/MissionCard.jsx
@@ -1,5 +1,5 @@
-import { Card, Box, CardContent, Grid, Typography, Button, Avatar } from "@material-ui/core";
-import { withStyles, createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
+import { Avatar, Box, Button, Card, CardContent, Grid, Typography } from "@material-ui/core";
+import { createMuiTheme, ThemeProvider, withStyles } from "@material-ui/core/styles";
 import GetAppIcon from "@material-ui/icons/GetApp";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import PublishIcon from "@material-ui/icons/Publish";
@@ -125,7 +125,6 @@ const styles = (theme) => ({
     color: theme.color.blue,
     zIndex: 1,
   },
-  actionButtons: {},
   greyBox: {
     background: "#F5F5F5",
     cursor: "pointer",
@@ -181,8 +180,7 @@ const MissionCard = withStyles(styles)(({ classes, mission }) => {
   const location = mission.pickUpLocation?.address || "no data";
   const dropOffLocation = mission.deliveryLocation?.address || "no data";
   const startTime = "" + (mission.pickUpWindow?.startTime || "");
-  const firebaseProfile = useSelector((state) => state.firebase.profile);
-  const user = firebaseProfile;
+  const user = useSelector((state) => state.firebase.profile);
   const fullScreen = useMediaQuery("(max-width:481px)");
   const [modalOpen, setModalOpen] = useState(false);
 

--- a/src/app/page/Home/VolunteerHomeMissionList.jsx
+++ b/src/app/page/Home/VolunteerHomeMissionList.jsx
@@ -6,6 +6,7 @@ import { Mission } from "../../model";
 import { MissionList, MissionGroup, ShowDeliveryRoute } from "../../component";
 import { Map, Marker, TileLayer } from "react-leaflet";
 import Box from "@material-ui/core/Box";
+import { useSelector } from "react-redux";
 
 const VolunteerHomeMissionList = ({
   action,
@@ -21,6 +22,7 @@ const VolunteerHomeMissionList = ({
   const history = useHistory();
 
   const { groups, singleMissions } = Mission.getAllGroups(missions);
+  const user = useSelector((state) => state.firebase.profile);
 
   const missionGroups = groups.map((group) => (
     <MissionGroup
@@ -34,6 +36,9 @@ const VolunteerHomeMissionList = ({
       callToAction={{
         text: actionText,
         icon: actionIcon,
+        onClick: (missionUid) => {
+          Mission.accept(user.uid, user, missionUid);
+        },
       }}
       history={history}
       isLoaded={isLoaded(group.missions)}


### PR DESCRIPTION
Fixes #627 

My IDE was complaining about a few things and fixed them itself. It alphabetized some imports, and removed a duplicate entry for actionButtons in MissionCard (line 159 is the second entry).

The actual fix was defining the function that Accept All would iterate over. I just modified the logic from `AcceptMission` in Mission Card and adapted it to a closure that was only passed the missionUid.